### PR TITLE
Update tag query logic to enforce stricter matching with "AND"

### DIFF
--- a/src/main/java/iudx/catalogue/server/mlayer/MlayerServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/mlayer/MlayerServiceImpl.java
@@ -295,7 +295,7 @@ public class MlayerServiceImpl implements MlayerService {
 
         for (Object tagValue : tagsArray) {
           if (tagValue instanceof String) {
-            tagQueryString = tagQueryString.concat(tagValue + " OR ");
+            tagQueryString = tagQueryString.concat(tagValue + " AND ");
           }
         }
 

--- a/src/main/java/iudx/catalogue/server/validator/Constants.java
+++ b/src/main/java/iudx/catalogue/server/validator/Constants.java
@@ -28,6 +28,13 @@ public class Constants {
           "{\"bool\":{\"must\":[{\"match\":{\"type.keyword\":\"$2\"}},"
               + "{\"match\":{\"$3.keyword\":\"$4\"}}]}}]}},\"_source\":[\"type\"]}");
 
+  public static final String RG_ITEM_EXISTS_QUERY =
+      ID_MATCH_SUB_QUERY.concat(
+          "{\"bool\":{\"must\":["
+              + "{\"match\":{\"type.keyword\":\"$2\"}},"
+              + "{\"match\":{\"$3.keyword\":\"$4\"}},"
+              + "{\"match\":{\"provider.keyword\":\"$1\"}}]}}]}},"
+              + "\"_source\":[\"type\"]}");
   public static final String PROVIDER_ITEM_EXISTS_QUERY =
       ID_MATCH_SUB_QUERY.concat(
           "{\"bool\":{\"must\":[{\"match\":{\"ownerUserId.keyword\":\"$2\"}},"

--- a/src/main/java/iudx/catalogue/server/validator/ValidatorServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/validator/ValidatorServiceImpl.java
@@ -211,7 +211,7 @@ public class ValidatorServiceImpl implements ValidatorService {
     request.put(ITEM_STATUS, ACTIVE).put(ITEM_CREATED_AT, getUtcDatetimeAsString());
     String provider = request.getString(PROVIDER);
     String checkQuery =
-        ITEM_EXISTS_QUERY
+        RG_ITEM_EXISTS_QUERY
             .replace("$1", provider)
             .replace("$2", ITEM_TYPE_RESOURCE_GROUP)
             .replace("$3", NAME)
@@ -233,7 +233,10 @@ public class ValidatorServiceImpl implements ValidatorService {
           } else if (method.equalsIgnoreCase(REQUEST_POST)
               && returnType.contains(ITEM_TYPE_RESOURCE_GROUP)) {
             LOGGER.debug("RG already exists");
-            handler.handle(Future.failedFuture("Fail: Resource Group item already exists"));
+            String errorMessage = String.format(
+                "Fail: Resource group item with the name '%s' already exists for the provider '%s'",
+                request.getString(NAME), provider);
+            handler.handle(Future.failedFuture(errorMessage));
           } else {
             handler.handle(Future.succeededFuture(request));
           }


### PR DESCRIPTION
This PR includes the following updates:

- Changed the logical operator in tag query construction from "OR" to "AND" to ensure stricter filtering of datasets. Datasets must now match all specified tags rather than any of them.
- Updated resource group item validation to ensure resource item names are unique within a provider.
- Improved error message to provide more clarity when duplicate resource group items are detected with the same names within the same provider.