### PR TITLE
instance field modified to include underscores

### DIFF
--- a/src/main/resources/iudx/catalogue/server/validator/mlayerDatasetSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/mlayerDatasetSchema.json
@@ -35,9 +35,10 @@
       "description": "Instance name from where the datasets belong to",
       "default": "",
       "examples": [
-        "pune"
+        "pune",
+        "rsac_up"
       ],
-      "pattern": "^[a-zA-Z ]*$"
+      "pattern": "^[a-zA-Z0-9_ ]*$"
     },
     "tags": {
       "$id": "#/properties/tags",


### PR DESCRIPTION
Update Dataset API: Modify 'instance' field in request body schema to allow underscores for 5.6.0 branch