### PR TITLE
Fix JDK version switch for integration tests on swarm deployment  

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -186,7 +186,8 @@ pipeline {
         stage('Integration test on swarm deployment') {
           steps {
             script{
-                sh 'mvn test-compile failsafe:integration-test -DskipUnitTests=true -DintTestDepl=true'
+              sh 'sudo update-alternatives --set java /usr/lib/jvm/java-21-openjdk-amd64/bin/java'
+              sh 'mvn test-compile failsafe:integration-test -DskipUnitTests=true -DintTestDepl=true'
             }
           }
           post{
@@ -198,6 +199,11 @@ pipeline {
             }
             failure{
               error "Test failure. Stopping pipeline execution!"
+            }
+            cleanup{
+              script{
+                sh 'sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java'
+              }
             }
           }
         }


### PR DESCRIPTION
* Updated Jenkinsfile to switch between JDK 21 and JDK 11 for the integration test on swarm deployment stage, ensuring compatibility with the deployment environment.  