### PR TITLE
Fix JSON Deserialization for Special Characters and Add Integration Test

### DIFF
--- a/src/test/java/iudx/catalogue/server/apiserver/integrationtests/searchAPIsIT/geoSpatialSearchIT/AttributeSearchIT.java
+++ b/src/test/java/iudx/catalogue/server/apiserver/integrationtests/searchAPIsIT/geoSpatialSearchIT/AttributeSearchIT.java
@@ -32,6 +32,20 @@ public class AttributeSearchIT {
                 .response();
     }
     @Test
+    @DisplayName("testing Attribute Search - 200 Success - Simple Attribute")
+    void GetSimpleAttributeForDxType() {
+        Response response = given()
+            .param("property","[type]")
+            .param("value","[[iudx:Resource, iudx:ResourceGroup]]")
+            .when()
+            .get("/search")
+            .then()
+            .statusCode(200)
+            .body("type", is("urn:dx:cat:Success"))
+            .extract()
+            .response();
+    }
+    @Test
     @DisplayName("testing Attribute Search - 200 Success - Simple Attribute Multi value")
     void GetSimpleAttributeMulVal() {
         Response response = given()


### PR DESCRIPTION
### Fix JSON Deserialization for Special Characters
* Enabled Jackson's ALLOW_COMMENTS and ALLOW_UNQUOTED_FIELD_NAMES to handle special characters in Elasticsearch responses.
* Configured Jackson to ignore unknown properties and handle null fields gracefully.
* Added an integration test for the Attribute Search API to validate searching with property=[type] and value=[[iudx:Resource, iudx:ResourceGroup]].