### PR TITLE
fix for out of bound exception in popularDataset API

### DIFF
--- a/src/main/java/iudx/catalogue/server/mlayer/service/MlayerServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/mlayer/service/MlayerServiceImpl.java
@@ -415,7 +415,7 @@ public class MlayerServiceImpl implements MlayerService {
   public Future<JsonObject> getMlayerPopularDatasets(String instance) {
     Promise<JsonObject> promise = Promise.promise();
     String query = GET_HIGH_COUNT_DATASET.replace("$1", databaseTable);
-    LOGGER.debug("postgres query" + query);
+    LOGGER.debug("postgres query " + query);
     postgresService.executeQuery(query).onComplete(dbHandler -> {
       if (dbHandler.succeeded()) {
         JsonArray popularDataset = dbHandler.result().getJsonArray("results");
@@ -436,7 +436,7 @@ public class MlayerServiceImpl implements MlayerService {
         mlayerPopularDatasets.getMlayerPopularDatasets(instance, popularRgs)
             .onComplete(getPopularDatasetsHandler -> {
               if (getPopularDatasetsHandler.succeeded()) {
-                LOGGER.info("Success: Getting data for the landing page.");
+                LOGGER.debug("Success: Getting data for the landing page.");
                 promise.complete(getPopularDatasetsHandler.result());
               } else {
                 LOGGER.error("Fail: Getting data for the landing page.");

--- a/src/main/java/iudx/catalogue/server/mlayer/service/MlayerServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/mlayer/service/MlayerServiceImpl.java
@@ -445,7 +445,7 @@ public class MlayerServiceImpl implements MlayerService {
             });
 
       } else {
-        LOGGER.debug("postgres query failed");
+        LOGGER.error("postgres query failed");
         promise.fail(dbHandler.cause());
       }
     });
@@ -482,7 +482,7 @@ public class MlayerServiceImpl implements MlayerService {
         JsonObject results = dbHandler.result();
         promise.complete(results);
       } else {
-        LOGGER.debug("postgres query failed");
+        LOGGER.error("postgres query failed");
         promise.fail(dbHandler.cause());
       }
     });

--- a/src/main/java/iudx/catalogue/server/mlayer/util/Constants.java
+++ b/src/main/java/iudx/catalogue/server/mlayer/util/Constants.java
@@ -7,9 +7,10 @@ public class Constants {
   public static final String INSTANCE_ID = "instanceId";
   public static final String DOMAIN_ID = "domainId";
   public static final String GET_HIGH_COUNT_DATASET =
-      "select resource_group, count(id) as totalhits from $1 "
-          + "group by resource_group order by totalhits "
-          + "desc limit 6";
+          "SELECT resource_group, COUNT(id) AS totalhits FROM $1 "
+            + "WHERE resource_group IS NOT NULL GROUP BY "
+            + "resource_group ORDER BY totalhits DESC LIMIT 6";
+
   public static final String TIME_QUERY = "where time between '$1' AND '$2'";
   public static final String COUNT_SIZE_QUERY =
       "select count(api) as counts , COALESCE(SUM(size), 0) as size from $a ";

--- a/src/main/java/iudx/catalogue/server/mlayer/util/model/MlayerPopularDatasets.java
+++ b/src/main/java/iudx/catalogue/server/mlayer/util/model/MlayerPopularDatasets.java
@@ -604,12 +604,13 @@ public class MlayerPopularDatasets {
                             }
                             JsonArray latestDatasets =
                                 responseMsg.getResponse().getJsonArray(RESULTS);
-                            int popularDatasetCount=0;
+                            int popularDatasetCount = 0;
                             int datasetIndex = 0;
-                            if (popularDatasets.size()<6) {
-                              popularDatasetCount=latestDatasets.size();
-                            } else
-                              popularDatasetCount= POPULAR_DATASET_COUNT;
+                            if (popularDatasets.size() < 6) {
+                              popularDatasetCount = latestDatasets.size();
+                            } else {
+                              popularDatasetCount = POPULAR_DATASET_COUNT;
+                            }
                             while (popularDatasets.size() < popularDatasetCount) {
 
                               if (!frequentlyUsedResourceGroup.contains(

--- a/src/main/java/iudx/catalogue/server/mlayer/util/model/MlayerPopularDatasets.java
+++ b/src/main/java/iudx/catalogue/server/mlayer/util/model/MlayerPopularDatasets.java
@@ -602,10 +602,15 @@ public class MlayerPopularDatasets {
                                 popularDatasets.add(resultItem);
                               }
                             }
-                            int datasetIndex = 0;
                             JsonArray latestDatasets =
                                 responseMsg.getResponse().getJsonArray(RESULTS);
-                            while (popularDatasets.size() < POPULAR_DATASET_COUNT) {
+                            int popularDatasetCount=0;
+                            int datasetIndex = 0;
+                            if (popularDatasets.size()<6) {
+                              popularDatasetCount=latestDatasets.size();
+                            } else
+                              popularDatasetCount= POPULAR_DATASET_COUNT;
+                            while (popularDatasets.size() < popularDatasetCount) {
 
                               if (!frequentlyUsedResourceGroup.contains(
                                   latestDatasets.getJsonObject(datasetIndex).getString("id"))) {


### PR DESCRIPTION
Fix added for array out of bound exception that occurs when elastic db has  less than 6 records or the popular dataset fetched from the postgres has less than 6 values . (6 is the response count of json objects in popular and featured datasets)