### PR TITLE
staging-fix for array out of bound

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
     stage('Unit Tests and CodeCoverage Test'){
       steps{
         script{
-          sh 'cp /home/ubuntu/configs/cat-config-test.json ./configs/config-test.json'
+          sh 'cp /home/ubuntu/configs/5.6.0/cat-config-test.json ./configs/config-test.json'
           sh 'mvn clean test checkstyle:checkstyle pmd:pmd'
         }
         xunit (
@@ -108,7 +108,7 @@ pipeline {
           }
         }
         script{
-            sh 'scp /home/ubuntu/configs/cat-config-test.json ./configs/config-test.json'
+            sh 'scp /home/ubuntu/configs/5.6.0/cat-config-test.json ./configs/config-test.json'
             sh 'mvn test-compile failsafe:integration-test -DskipUnitTests=true -DintTestProxyHost=jenkins-master-priv -DintTestProxyPort=8090 -DintTestHost=jenkins-slave1 -DintTestPort=8080'
         }
         node('built-in') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - WORKSPACE
       - LOG_LEVEL=INFO
     volumes:
-      - /home/ubuntu/configs/cat-config-test.json:/usr/share/app/configs/config-test.json
+      - /home/ubuntu/configs/5.6.0/cat-config-test.json:/usr/share/app/configs/config-test.json
       - ./src/:/usr/share/app/src
       - ./docker/runTests.sh:/usr/share/app/docker/runTests.sh
       - ${WORKSPACE}:/tmp/test
@@ -84,7 +84,7 @@ services:
       - WORKSPACE
       - LOG_LEVEL=INFO
     volumes:
-      - /home/ubuntu/configs/cat-config-dev.json:/usr/share/app/configs/config.json
+      - /home/ubuntu/configs/5.6.0/cat-config-dev.json:/usr/share/app/configs/config.json
     ports:
       - "8080:8080"
     command: bash -c "exec java $$CAT_JAVA_OPTS  -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar ./fatjar.jar  --host $$(hostname) -c configs/config.json"

--- a/src/main/java/iudx/catalogue/server/database/mlayer/MlayerPopularDatasets.java
+++ b/src/main/java/iudx/catalogue/server/database/mlayer/MlayerPopularDatasets.java
@@ -428,11 +428,17 @@ public class MlayerPopularDatasets {
                       }
                     }
                     int datasetIndex = 0;
+                    int popularDatasetCount = 0;
+                    if (popularDatasets.size() < 6) {
+                      popularDatasetCount = latestDatasets.size();
+                    } else {
+                      popularDatasetCount = POPULAR_DATASET_COUNT;
+                    }
 
-                    while (popularDatasets.size() < POPULAR_DATASET_COUNT) {
+                    while (popularDatasets.size() < popularDatasetCount) {
 
                       if (!frequentlyUsedResourceGroup.contains(
-                          latestDatasets.getJsonObject(datasetIndex).getString("id"))) {
+                              latestDatasets.getJsonObject(datasetIndex).getString("id"))) {
                         popularDatasets.add(latestDatasets.getJsonObject(datasetIndex));
                         datasetIndex++;
                       }

--- a/src/main/java/iudx/catalogue/server/database/mlayer/MlayerPopularDatasets.java
+++ b/src/main/java/iudx/catalogue/server/database/mlayer/MlayerPopularDatasets.java
@@ -427,21 +427,25 @@ public class MlayerPopularDatasets {
                         popularDatasets.add(resultItem);
                       }
                     }
+                    int popularDatasetCount = (popularDatasets.size() < 6) ? latestDatasets.size() : POPULAR_DATASET_COUNT;
+                    LOGGER.debug("Target popular dataset count: {}", popularDatasetCount);
+
                     int datasetIndex = 0;
-                    int popularDatasetCount = 0;
-                    if (popularDatasets.size() < 6) {
-                      popularDatasetCount = latestDatasets.size();
-                    } else {
-                      popularDatasetCount = POPULAR_DATASET_COUNT;
+                    while (popularDatasets.size() < popularDatasetCount && datasetIndex < latestDatasets.size()) {
+                      String datasetId = latestDatasets.getJsonObject(datasetIndex).getString("id");
+
+                      if (!frequentlyUsedResourceGroup.contains(datasetId)) {
+                        popularDatasets.add(latestDatasets.getJsonObject(datasetIndex));
+                        LOGGER.debug("Added dataset with id: {}", datasetId);
+                      }
+
+                      datasetIndex++;
                     }
 
-                    while (popularDatasets.size() < popularDatasetCount) {
-
-                      if (!frequentlyUsedResourceGroup.contains(
-                              latestDatasets.getJsonObject(datasetIndex).getString("id"))) {
-                        popularDatasets.add(latestDatasets.getJsonObject(datasetIndex));
-                        datasetIndex++;
-                      }
+                    if (popularDatasets.size() < popularDatasetCount) {
+                      LOGGER.debug("Could not reach the target count of popular datasets. Collected: {}", popularDatasets.size());
+                    } else {
+                      LOGGER.debug("Successfully collected {} popular datasets.", popularDatasets.size());
                     }
                     JsonArray allRgId = new JsonArray();
                     for (int count = 0; count < popularDatasets.size(); count++) {

--- a/src/main/java/iudx/catalogue/server/database/mlayer/MlayerPopularDatasets.java
+++ b/src/main/java/iudx/catalogue/server/database/mlayer/MlayerPopularDatasets.java
@@ -427,11 +427,13 @@ public class MlayerPopularDatasets {
                         popularDatasets.add(resultItem);
                       }
                     }
-                    int popularDatasetCount = (popularDatasets.size() < 6) ? latestDatasets.size() : POPULAR_DATASET_COUNT;
+                    int popularDatasetCount = (popularDatasets.size() < 6)
+                            ? latestDatasets.size() : POPULAR_DATASET_COUNT;
                     LOGGER.debug("Target popular dataset count: {}", popularDatasetCount);
 
                     int datasetIndex = 0;
-                    while (popularDatasets.size() < popularDatasetCount && datasetIndex < latestDatasets.size()) {
+                    while (popularDatasets.size() < popularDatasetCount
+                            && datasetIndex < latestDatasets.size()) {
                       String datasetId = latestDatasets.getJsonObject(datasetIndex).getString("id");
 
                       if (!frequentlyUsedResourceGroup.contains(datasetId)) {
@@ -443,9 +445,11 @@ public class MlayerPopularDatasets {
                     }
 
                     if (popularDatasets.size() < popularDatasetCount) {
-                      LOGGER.debug("Could not reach the target count of popular datasets. Collected: {}", popularDatasets.size());
+                      LOGGER.debug("Could not reach the target count of popular datasets. "
+                              + "Collected: {}", popularDatasets.size());
                     } else {
-                      LOGGER.debug("Successfully collected {} popular datasets.", popularDatasets.size());
+                      LOGGER.debug("Successfully collected {} popular datasets.",
+                              popularDatasets.size());
                     }
                     JsonArray allRgId = new JsonArray();
                     for (int count = 0; count < popularDatasets.size(); count++) {

--- a/src/main/java/iudx/catalogue/server/mlayer/MlayerServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/mlayer/MlayerServiceImpl.java
@@ -349,7 +349,7 @@ public class MlayerServiceImpl implements MlayerService {
   public MlayerService getMlayerPopularDatasets(
       String instance, Handler<AsyncResult<JsonObject>> handler) {
     String query = GET_HIGH_COUNT_DATASET.replace("$1", databaseTable);
-    LOGGER.debug("postgres query" + query);
+    LOGGER.debug("postgres query " + query);
     postgresService.executeQuery(
         query,
         dbHandler -> {
@@ -379,7 +379,7 @@ public class MlayerServiceImpl implements MlayerService {
                 });
 
           } else {
-            LOGGER.debug("postgres query failed");
+            LOGGER.error("postgres query failed");
             handler.handle(Future.failedFuture(dbHandler.cause()));
           }
         });

--- a/src/main/java/iudx/catalogue/server/mlayer/util/Constants.java
+++ b/src/main/java/iudx/catalogue/server/mlayer/util/Constants.java
@@ -7,9 +7,9 @@ public class Constants {
   public static final String INSTANCE_ID = "instanceId";
   public static final String DOMAIN_ID = "domainId";
   public static final String GET_HIGH_COUNT_DATASET =
-      "select resource_group, count(id) as totalhits from $1 "
-          + "group by resource_group order by totalhits "
-          + "desc limit 6";
+      "SELECT resource_group, COUNT(id) AS totalhits FROM $1 "
+           + "WHERE resource_group IS NOT NULL GROUP BY "
+           + "resource_group ORDER BY totalhits DESC LIMIT 6";
   public static final String TIME_QUERY = "where time between '$1' AND '$2'";
   public static final String COUNT_SIZE_QUERY =
       "select count(api) as counts , COALESCE(SUM(size), 0) as size from $a ";

--- a/src/test/java/iudx/catalogue/server/database/DatabaseServiceImplTest.java
+++ b/src/test/java/iudx/catalogue/server/database/DatabaseServiceImplTest.java
@@ -24,6 +24,7 @@ import jdk.jfr.Description;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,7 +32,7 @@ import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
-
+@Disabled
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(VertxExtension.class)
 public class DatabaseServiceImplTest {

--- a/src/test/java/iudx/catalogue/server/database/DatabaseServiceImplTest.java
+++ b/src/test/java/iudx/catalogue/server/database/DatabaseServiceImplTest.java
@@ -32,7 +32,7 @@ import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
-@Disabled
+
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(VertxExtension.class)
 public class DatabaseServiceImplTest {

--- a/src/test/java/iudx/catalogue/server/database/DatabaseServiceTest.java
+++ b/src/test/java/iudx/catalogue/server/database/DatabaseServiceTest.java
@@ -28,7 +28,7 @@ import org.mockito.stubbing.Answer;
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(VertxExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@Disabled
+
 public class DatabaseServiceTest {
   private static final Logger LOGGER = LogManager.getLogger(DatabaseServiceTest.class);
   private static DatabaseService dbService;

--- a/src/test/java/iudx/catalogue/server/database/DatabaseServiceTest.java
+++ b/src/test/java/iudx/catalogue/server/database/DatabaseServiceTest.java
@@ -18,13 +18,7 @@ import iudx.catalogue.server.geocoding.GeocodingService;
 import iudx.catalogue.server.nlpsearch.NLPSearchService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
@@ -34,6 +28,7 @@ import org.mockito.stubbing.Answer;
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(VertxExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Disabled
 public class DatabaseServiceTest {
   private static final Logger LOGGER = LogManager.getLogger(DatabaseServiceTest.class);
   private static DatabaseService dbService;

--- a/src/test/java/iudx/catalogue/server/database/ElasticClientTest.java
+++ b/src/test/java/iudx/catalogue/server/database/ElasticClientTest.java
@@ -31,7 +31,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(VertxExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@Disabled
 public class ElasticClientTest {
   @Mock
   Handler<AsyncResult<JsonObject>> handler;

--- a/src/test/java/iudx/catalogue/server/database/ElasticClientTest.java
+++ b/src/test/java/iudx/catalogue/server/database/ElasticClientTest.java
@@ -22,12 +22,7 @@ import io.vertx.junit5.VertxTestContext;
 import io.vertx.core.Vertx;
 import iudx.catalogue.server.Configuration;
 import org.elasticsearch.client.Request;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -36,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(VertxExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Disabled
 public class ElasticClientTest {
   @Mock
   Handler<AsyncResult<JsonObject>> handler;

--- a/src/test/java/iudx/catalogue/server/database/QueryDecoderTest.java
+++ b/src/test/java/iudx/catalogue/server/database/QueryDecoderTest.java
@@ -24,6 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(VertxExtension.class)
 @ExtendWith(MockitoExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Disabled
 public class QueryDecoderTest {
 
   private static QueryDecoder queryDecoder;

--- a/src/test/java/iudx/catalogue/server/database/QueryDecoderTest.java
+++ b/src/test/java/iudx/catalogue/server/database/QueryDecoderTest.java
@@ -24,7 +24,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(VertxExtension.class)
 @ExtendWith(MockitoExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@Disabled
 public class QueryDecoderTest {
 
   private static QueryDecoder queryDecoder;

--- a/src/test/java/iudx/catalogue/server/database/SummarizerTest.java
+++ b/src/test/java/iudx/catalogue/server/database/SummarizerTest.java
@@ -11,7 +11,7 @@ import io.vertx.core.json.JsonObject;
 
 @ExtendWith(VertxExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@Disabled
+
 public class SummarizerTest {
 
   private static final Logger LOGGER = LogManager.getLogger(SummarizerTest.class);

--- a/src/test/java/iudx/catalogue/server/database/SummarizerTest.java
+++ b/src/test/java/iudx/catalogue/server/database/SummarizerTest.java
@@ -1,9 +1,6 @@
 package iudx.catalogue.server.database;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -14,6 +11,7 @@ import io.vertx.core.json.JsonObject;
 
 @ExtendWith(VertxExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Disabled
 public class SummarizerTest {
 
   private static final Logger LOGGER = LogManager.getLogger(SummarizerTest.class);


### PR DESCRIPTION
Fix added for array out of bound exception that occurs when elastic db has less than 6 records or the popular dataset fetched from the postgres has less than 6 values . (6 is the response count of json objects in popular and featured datasets)