### PR TITLE
feat: integrate AI sandbox support with schema and API updates

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -36,7 +36,7 @@ info:
        - <b>/internal/ui/instance</b>
        - <b>/internal/ui/domain</b>
        - <b>/internal/ui/dataset</b>
-       
+    
     Additional query parameters to be used:
       - <b>offset</b> : The from parameter defines the offset from the first result you want to fetch,  ( <i>default : 0</i> ,<i>minValue: 0</i>, <i>maxValue: 10000</i> )
       - <b>limit</b> : The size parameter allows you to configure the maximum results to be returned  ( <i>default: 10000</i> ,<i>minValue: 0</i>, <i>maxValue: 10000</i> )
@@ -628,6 +628,9 @@ paths:
                 - $ref: '#/components/schemas/exampleEntityProvider'
                 - $ref: '#/components/schemas/exampleEntityResourceGroup'
                 - $ref: '#/components/schemas/exampleEntityResource'
+                - $ref: '#/components/schemas/exampleEntityAIModel'
+                - $ref: '#/components/schemas/exampleEntityDataBank'
+                - $ref: '#/components/schemas/exampleEntityAdexApps'
       responses:
         '201':
           description: Successfully inserted
@@ -641,6 +644,9 @@ paths:
                   - $ref: '#/components/schemas/successResponseForCreateProviderEntity'
                   - $ref: '#/components/schemas/successResponseForCreateResourceGroupEntity'
                   - $ref: '#/components/schemas/successResponseForCreateResourceEntity'
+                  - $ref: '#/components/schemas/successResponseForCreateAIModelEntity'
+                  - $ref: '#/components/schemas/successResponseForCreateDataBankResourceEntity'
+                  - $ref: '#/components/schemas/successResponseForCreateAdexAppsEntity'
         '400':
           description: Invalid document
           content:
@@ -749,6 +755,9 @@ paths:
                 - $ref: '#/components/schemas/exampleEntityWIdProvider'
                 - $ref: '#/components/schemas/exampleEntityWIdResourceGroup'
                 - $ref: '#/components/schemas/exampleEntityWIdResource'
+                - $ref: '#/components/schemas/exampleEntityWIdAIModel'
+                - $ref: '#/components/schemas/exampleEntityWIdDataBankResource'
+                - $ref: '#/components/schemas/exampleEntityWIdAdexApps'
       responses:
         '200':
           description: Successfully inserted
@@ -762,6 +771,9 @@ paths:
                   - $ref: '#/components/schemas/successResponseForUpdateProviderEntity'
                   - $ref: '#/components/schemas/successResponseForUpdateResourceGroupEntity'
                   - $ref: '#/components/schemas/successResponseForUpdateResourceEntity'
+                  - $ref: '#/components/schemas/successResponseForUpdateAIModelEntity'
+                  - $ref: '#/components/schemas/successResponseForUpdateDataBankEntity'
+                  - $ref: '#/components/schemas/successResponseForUpdateAdexAppsEntity'
         '400':
           description: Bad Request
           content:
@@ -826,6 +838,9 @@ paths:
                   - $ref: '#/components/schemas/successResponseForGetProviderEntity'
                   - $ref: '#/components/schemas/successResponseForGetResourceGroupEntity'
                   - $ref: '#/components/schemas/successResponseForGetResourceEntity'
+                  - $ref: '#/components/schemas/successResponseForGetAIModelEntity'
+                  - $ref: '#/components/schemas/successResponseForGetDataBankEntity'
+                  - $ref: '#/components/schemas/successResponseForGetAdexAppsEntity'
         '400':
           description: Invalid ID.
           content:
@@ -843,7 +858,7 @@ paths:
                 title: 'error'
                 totalHits: 0
                 results:
-                  []
+                  [ ]
                 details: "doc doesn't exist"
 
       servers:
@@ -2259,104 +2274,104 @@ paths:
                     type: "urn:dx:cat:Success"
                     title: "Success"
                     results:
-                      -  accessPolicy: "OPEN"
-                         apdURL: "acl-apd.iudx.io"
-                         provider: "bbeacb12-5e54-339d-92e0-d8e063b551a8"
-                         resourceServer: "49cf5c76-09de-11ee-be56-0242ac120002"
-                         owner: "13bf961b-b1f4-3f7f-a651-b1b1965a4067"
-                         resourceGroup: "1173f774-794e-4ed0-9c41-281256d44b6a"
-                         instance: "pune"
-                         iudxResourceAPIs:
-                           - "SPATIAL"
-                           - "ATTR"
-                         _geosummary:
-                           _geocoded:
-                             results:
-                               - country: "India"
-                                 bbox: [ 76.703813, 30.665456, 76.848368, 30.795316 ]
-                                 name: "Chandigarh"
-                                 county: "Chandigarh"
-                                 locality: "Chandigarh"
-                                 region: "Chandigarh"
-                               - country: "India"
-                                 bbox: [ 76.95681, 28.07989, 76.99681, 28.11989 ]
-                                 name: "Chandigarh"
-                                 county: "Mewat"
-                                 locality: "Chandigarh"
-                                 region: "Haryana"
-                           _reverseGeocoded: { }
-                         description: "Paid parking locations in Chandigarh city."
-                         label: "Chandigarh Paid Parking Locations"
-                         type:
-                           - "iudx:Resource"
-                           - "iudx:PointOfInterest"
-                         '@context': "https://voc.iudx.org.in/"
-                         tags:
-                           - "parking"
-                           - "docking"
-                           - "leave"
-                           - "station"
-                           - "stop"
-                           - "places"
-                           - "parking lot"
-                           - "paid parking"
-                           - "vehicle"
-                           - "car"
-                           - "bike"
-                           - "scooter"
-                           - "two-wheeler"
-                           - "four-wheeler"
-                           - "vehicle wheeler"
-                         itemCreatedAt: "2023-09-15T05:59:05+0530"
-                         dataSampleFile:
-                           - relationType: "REL_FILE"
-                             hasObject: "https://fs-sample-file-bucket.s3.ap-south-1.amazonaws.com/public-access/chandigarh/chandigarh-paid-parking-locations.json"
-                             name: "Chandigarh Paid parking locations sample"
-                             description: "Sample file for Paid parking locations in Chandigarh City."
-                         itemStatus: "ACTIVE"
-                         name: "paid-parking-locations"
-                         location:
-                           address: "Chandigarh"
-                           geometry:
-                             coordinates:
-                               - [ 76.573333, 30.758358 ]
-                               - [ 76.551361, 30.637912 ]
-                               - [ 76.755981, 30.582361 ]
-                               - [ 76.929016, 30.649727 ]
-                               - [ 76.974334, 30.802012 ]
-                               - [ 76.766967, 30.872761 ]
-                               - [ 76.573333, 30.758358 ]
-                             type: "Polygon"
-                           type: "Place"
-                         id: "a347c5b6-5281-4749-9eab-89784d8f8f9a"
-                         dataSample:
-                           address: "AFEEM KOTHI CHAURAHA"
-                           name: "Paid Parking Camera- AFEEM KOTHI CHAURAHA"
-                           location:
-                             coordinates: [ 80.333972, 26.455667 ]
-                             type: "Point"
-                         dataDescriptor:
-                           address:
-                             dataSchema: "iudx:Text"
-                             description: "Name of the area or locality at which the Paid parking locations is located in Chandigarh city."
-                             type: [ "ValueDescriptor" ]
-                           name:
-                             dataSchema: "iudx:Text"
-                             description: "Name of the Paid parking locations corresponding to this observation."
-                             type: [ "ValueDescriptor" ]
-                           dataDescriptorLabel: "Data Descriptor for Paid parking locations in Chandigarh City"
-                           description: "Data attribute definitions of all Paid parking locations in Chandigarh city."
-                           location:
-                             dataSchema: "iudx:Point"
-                             description: "Physical coordinates of the Paid parking locations corresponding to this observation."
-                             type: [ "ValueDescriptor" ]
-                           type:
-                             - "iudx:DataDescriptor"
-                             - "iudx:PointOfInterest"
-                           '@context': "https://voc.iudx.org.in/"
-                         resourceType: "GSLAYER"
-                         ownerUserId: "b2c27f3f-2524-4a84-816e-91f9ab23f837"
-                         cos: "637e32b6-9a6c-396f-914c-9db5d1a222b0"
+                      - accessPolicy: "OPEN"
+                        apdURL: "acl-apd.iudx.io"
+                        provider: "bbeacb12-5e54-339d-92e0-d8e063b551a8"
+                        resourceServer: "49cf5c76-09de-11ee-be56-0242ac120002"
+                        owner: "13bf961b-b1f4-3f7f-a651-b1b1965a4067"
+                        resourceGroup: "1173f774-794e-4ed0-9c41-281256d44b6a"
+                        instance: "pune"
+                        iudxResourceAPIs:
+                          - "SPATIAL"
+                          - "ATTR"
+                        _geosummary:
+                          _geocoded:
+                            results:
+                              - country: "India"
+                                bbox: [ 76.703813, 30.665456, 76.848368, 30.795316 ]
+                                name: "Chandigarh"
+                                county: "Chandigarh"
+                                locality: "Chandigarh"
+                                region: "Chandigarh"
+                              - country: "India"
+                                bbox: [ 76.95681, 28.07989, 76.99681, 28.11989 ]
+                                name: "Chandigarh"
+                                county: "Mewat"
+                                locality: "Chandigarh"
+                                region: "Haryana"
+                          _reverseGeocoded: { }
+                        description: "Paid parking locations in Chandigarh city."
+                        label: "Chandigarh Paid Parking Locations"
+                        type:
+                          - "iudx:Resource"
+                          - "iudx:PointOfInterest"
+                        '@context': "https://voc.iudx.org.in/"
+                        tags:
+                          - "parking"
+                          - "docking"
+                          - "leave"
+                          - "station"
+                          - "stop"
+                          - "places"
+                          - "parking lot"
+                          - "paid parking"
+                          - "vehicle"
+                          - "car"
+                          - "bike"
+                          - "scooter"
+                          - "two-wheeler"
+                          - "four-wheeler"
+                          - "vehicle wheeler"
+                        itemCreatedAt: "2023-09-15T05:59:05+0530"
+                        dataSampleFile:
+                          - relationType: "REL_FILE"
+                            hasObject: "https://fs-sample-file-bucket.s3.ap-south-1.amazonaws.com/public-access/chandigarh/chandigarh-paid-parking-locations.json"
+                            name: "Chandigarh Paid parking locations sample"
+                            description: "Sample file for Paid parking locations in Chandigarh City."
+                        itemStatus: "ACTIVE"
+                        name: "paid-parking-locations"
+                        location:
+                          address: "Chandigarh"
+                          geometry:
+                            coordinates:
+                              - [ 76.573333, 30.758358 ]
+                              - [ 76.551361, 30.637912 ]
+                              - [ 76.755981, 30.582361 ]
+                              - [ 76.929016, 30.649727 ]
+                              - [ 76.974334, 30.802012 ]
+                              - [ 76.766967, 30.872761 ]
+                              - [ 76.573333, 30.758358 ]
+                            type: "Polygon"
+                          type: "Place"
+                        id: "a347c5b6-5281-4749-9eab-89784d8f8f9a"
+                        dataSample:
+                          address: "AFEEM KOTHI CHAURAHA"
+                          name: "Paid Parking Camera- AFEEM KOTHI CHAURAHA"
+                          location:
+                            coordinates: [ 80.333972, 26.455667 ]
+                            type: "Point"
+                        dataDescriptor:
+                          address:
+                            dataSchema: "iudx:Text"
+                            description: "Name of the area or locality at which the Paid parking locations is located in Chandigarh city."
+                            type: [ "ValueDescriptor" ]
+                          name:
+                            dataSchema: "iudx:Text"
+                            description: "Name of the Paid parking locations corresponding to this observation."
+                            type: [ "ValueDescriptor" ]
+                          dataDescriptorLabel: "Data Descriptor for Paid parking locations in Chandigarh City"
+                          description: "Data attribute definitions of all Paid parking locations in Chandigarh city."
+                          location:
+                            dataSchema: "iudx:Point"
+                            description: "Physical coordinates of the Paid parking locations corresponding to this observation."
+                            type: [ "ValueDescriptor" ]
+                          type:
+                            - "iudx:DataDescriptor"
+                            - "iudx:PointOfInterest"
+                          '@context': "https://voc.iudx.org.in/"
+                        resourceType: "GSLAYER"
+                        ownerUserId: "b2c27f3f-2524-4a84-816e-91f9ab23f837"
+                        cos: "637e32b6-9a6c-396f-914c-9db5d1a222b0"
         '404':
           description: Bad Request
           content:
@@ -4096,6 +4111,261 @@ components:
         resourceServer: '{{uuid}}'
         provider: '{uuid}}'
         resourceGroup: '{{uuid}}'
+    exampleEntityWIdAIModel:
+      type: object
+      title: AI Model entity
+      description: An example AI model entity for first-time onboarding (without system-generated fields like itemCreatedAt or itemStatus)
+      properties:
+        '@context':
+          type: string
+          format: uri
+        id:
+          type: string
+          pattern: '^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$'
+        name:
+          type: string
+          pattern: '^[a-zA-Z0-9]([\\w-]*[a-zA-Z0-9 ])?$'
+          maxLength: 512
+        type:
+          type: array
+          items:
+            type: string
+        label:
+          type: string
+          maxLength: 512
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        provider:
+          type: string
+          pattern: '^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$'
+        accessPolicy:
+          type: string
+          pattern: '^(RESTRICTED|OPEN|PII|restricted|open|pii)$'
+        organizationType:
+          type: string
+          enum: [ 'Private', 'Government' ]
+        department:
+          type: string
+        modelType:
+          type: string
+        fileFormat:
+          type: string
+        required:
+          - type
+          - name
+          - label
+          - description
+          - tags
+          - provider
+          - accessPolicy
+          - organizationType
+          - department
+          - modelType
+          - fileFormat
+      example:
+        '@context': 'https://voc.iudx.org.in/'
+        id: '337545aa-1fa5-4ca0-bf3d-072144dec5b6'
+        type:
+          - 'adex:AiModel'
+        name: 'ai-model-crop'
+        label: 'Test-Crop Disease Detection Model'
+        description: 'A test AI model for detecting crop disease with the help of infected leaf images.'
+        tags:
+          - ai
+          - ml
+          - model
+          - ai-model
+          - ml-model
+          - machine
+          - learning
+          - machine learning
+          - training
+          - algorithm
+        provider: '337545aa-1fa5-4ca0-bf3d-072144dec5b6'
+        accessPolicy: 'RESTRICTED'
+        organizationType: 'Private'
+        department: 'Agriculture and Co-operation'
+        modelType: 'ImageClassifier'
+        fileFormat: 'ipynb'
+    exampleEntityWIdDataBankResource:
+      type: object
+      title: data bank resource entity
+      description: payload for update item with ID
+      properties:
+        '@context':
+          type: string
+        type:
+          type: array
+          items:
+            type: string
+        name:
+          type: string
+        label:
+          type: string
+        description:
+          type: string
+        provider:
+          type: string
+          format: uuid
+        resourceGroup:
+          type: string
+          format: uuid
+        resourceServer:
+          type: string
+          format: uuid
+        tags:
+          type: array
+          items:
+            type: string
+        accessPolicy:
+          type: string
+        organizationType:
+          type: string
+        fileFormat:
+          type: string
+        dataReadiness:
+          type: string
+        department:
+          type: string
+        resourceType:
+          type: string
+        adexResourceAPIs:
+          type: array
+          items:
+            type: string
+        iudxResourceAPIs:
+          type: array
+          items:
+            type: string
+        location:
+          type: object
+          additionalProperties: true
+        dataDescriptor:
+          type: object
+          additionalProperties: true
+        dataSample:
+          type: object
+          additionalProperties: true
+      required:
+        - type
+        - name
+        - label
+        - description
+        - provider
+        - resourceGroup
+        - resourceServer
+        - tags
+        - accessPolicy
+        - organizationType
+        - fileFormat
+        - dataReadiness
+        - department
+        - resourceType
+        - adexResourceAPIs
+        - iudxResourceAPIs
+        - location
+        - dataDescriptor
+        - dataSample
+      example:
+        '@context': 'https://voc.iudx.org.in/'
+        type:
+          - 'adex:DataBank'
+        name: subdistrict-weather-info
+        label: Subdistrict Weather Info
+        description: Weather related statistics like rainfall and temperature for subdistricts.
+        provider: '337545aa-1fa5-4ca0-bf3d-072144dec5b6'
+        resourceGroup: '96bc97bf-504e-4306-bb49-99d77896cf1d'
+        resourceServer: '{{UUID}}'
+        tags:
+          - environment
+          - weather
+          - rainfall
+          - temperature
+        accessPolicy: RESTRICTED
+        organizationType: Private
+        fileFormat: .xlsx
+        dataReadiness: More than 80%
+        department: Department of IT, Electronics and Communication
+        resourceType: MESSAGESTREAM
+        adexResourceAPIs:
+          - TEMPORAL
+          - ATTR
+        iudxResourceAPIs:
+          - TEMPORAL
+          - LOCATION
+        location:
+          latitude: 12.9716
+          longitude: 77.5946
+        dataDescriptor:
+          schema: Custom schema here
+        dataSample:
+          temperature: 24
+          rainfall: 5
+          observationDateTime: '2023-02-03T08:30:00+05:30'
+    exampleEntityWIdAdexApps:
+      type: object
+      title: ADeX App entity
+      description: An example ADeX potential application entity for onboarding
+      properties:
+        '@context':
+          type: string
+          format: uri
+        id:
+          type: string
+          pattern: '^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$'
+        name:
+          type: string
+          pattern: '^[a-zA-Z0-9]([\\w-]*[a-zA-Z0-9 ])?$'
+          maxLength: 512
+        type:
+          type: array
+          items:
+            type: string
+        label:
+          type: string
+          maxLength: 512
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        organizationType:
+          type: string
+          enum: [ 'Private', 'Government' ]
+        department:
+          type: string
+      required:
+        - type
+        - name
+        - label
+        - description
+        - tags
+        - organizationType
+        - department
+      example:
+        type:
+          - 'adex:Apps'
+        name: 'crop-disease-app'
+        label: 'Test-Crop Disease Detection Model'
+        description: 'A test potential application item for detecting crop disease with the help of infected leaf images.'
+        tags:
+          - ai
+          - ml
+          - model
+          - ai-model
+          - ml-model
+          - machine
+          - learning
+          - machine learning
+          - training
+          - algorithm
+        organizationType: 'Private'
+        department: 'Agriculture and Co-operation'
     updateItemResponse:
       type: object
       title: Response for update Item
@@ -4809,6 +5079,345 @@ components:
           itemStatus: "ACTIVE"
           itemCreatedAt: "2024-01-07T04:53:31+0530"
           _summary: "iudxResourceItemPM item for test only swachhata complaints construction material requests resource item for the postman collection"
+    successResponseForCreateAIModelEntity:
+      type: object
+      title: AI Model Entity
+      description: An AI Model item is successfully created
+      properties:
+        type:
+          type: string
+          description: |
+            URN type of the response indicating if the query was successful or if any errors have been triggered
+        title:
+          type: string
+          description: A human-readable title for the message response
+        detail:
+          type: string
+          description: Detailed description of the type or response
+        results:
+          type: object
+          properties:
+            '@context':
+              type: string
+              format: uri
+              description: JSON-LD context URI
+            id:
+              type: string
+              pattern: "^[a-zA-Z0-9\\-]{36}$"
+              description: Unique identifier of the model item
+            type:
+              type: array
+              items:
+                type: string
+              description: Type tags from the ADeX vocabulary
+            name:
+              type: string
+              maxLength: 512
+              pattern: "^[a-zA-Z0-9]([\\w-]*[a-zA-Z0-9 ])?$"
+              description: Name of the AI Model item
+            provider:
+              type: string
+              format: uuid
+              maxLength: 36
+              description: Provider id of the AI Model item
+            tags:
+              type: array
+              items:
+                type: string
+              description: Tags associated with the AI Model item
+            accessPolicy:
+              type: string
+              pattern: "^(RESTRICTED|OPEN|PII|restricted|open|pii)$"
+              description: Access policy for the model
+            label:
+              type: string
+              maxLength: 512
+              description: User-friendly label for the model
+            description:
+              type: string
+              description: Detailed description of the model
+            organizationType:
+              type: string
+              description: Type of organization providing the model
+            department:
+              type: string
+              description: Department name
+            modelType:
+              type: string
+              description: Type of model (e.g., ImageClassifier, TimeSeriesPredictor)
+            fileFormat:
+              type: string
+              description: File format of the model
+            itemStatus:
+              type: string
+              enum: [ "ACTIVE", "INACTIVE" ]
+              description: Current status of the model
+            itemCreatedAt:
+              type: string
+              format: date-time
+              description: Creation timestamp of the model item
+          required:
+            - '@context'
+            - id
+            - type
+            - name
+            - provider
+            - tags
+            - accessPolicy
+            - label
+            - description
+            - organizationType
+            - department
+            - modelType
+            - fileFormat
+            - itemStatus
+            - itemCreatedAt
+      example:
+        type: 'urn:dx:cat:Success'
+        title: 'Success'
+        detail: 'Success: Item created'
+        results:
+          '@context': "https://voc.iudx.org.in/"
+          id: "bc87aba4-0dcf-4c07-b9e4-55bdf683ae2a"
+          type:
+            - "adex:AiModel"
+          name: "ai-model-crop"
+          provider: "8fe8d1dd-ae51-4ff8-b995-13bce85d9d88"
+          tags:
+            - "ai"
+            - "ml"
+            - "model"
+          accessPolicy: "RESTRICTED"
+          label: "Test-Crop Disease Detection Model"
+          description: "An test AI model for detecting crop disease with the help of infected leaf images."
+          organizationType: "Private"
+          department: "Agriculture and Co-operation"
+          modelType: "ImageClassifier"
+          fileFormat: "ipynb"
+          itemStatus: "ACTIVE"
+          itemCreatedAt: "2024-01-05T02:09:10+0530"
+    successResponseForCreateDataBankResourceEntity:
+      type: object
+      title: Data Bank Resource Entity
+      description: A Data Bank Resource item is successfully created
+      properties:
+        type:
+          type: string
+          description: |
+            URN type of the response indicating if the query was successful or if any errors have been triggered
+        title:
+          description: A human-readable title for the message response
+        detail:
+          type: string
+          description: Detailed description of the type or response
+        results:
+          type: object
+          properties:
+            '@context':
+              type: string
+              description: Context URL of the Data Bank Resource item.
+            id:
+              type: string
+              description: ID of the Data Bank Resource item.
+            type:
+              type: array
+              items:
+                type: string
+              description: Type of the Data Bank Resource item.
+            description:
+              type: string
+              description: Description of the Data Bank Resource item.
+            label:
+              type: string
+              description: Label of the Data Bank Resource item.
+            tags:
+              type: array
+              items:
+                type: string
+              description: Tags associated with the Data Bank Resource item.
+            provider:
+              type: string
+              description: Provider id of the Data Bank Resource item.
+              format: uuid
+            itemStatus:
+              type: string
+              description: Status of the Data Bank Resource item.
+            itemCreatedAt:
+              type: string
+              format: date-time
+              description: Creation timestamp of the Data Bank Resource item.
+            domain:
+              type: array
+              items:
+                type: string
+              description: The domain(s) that the Data Bank Resource item belongs to.
+          required:
+            - name
+            - type
+            - label
+            - description
+            - tags
+            - provider
+            - resourceGroup
+            - resourceServer
+            - accessPolicy
+            - organizationType
+            - fileFormat
+            - dataReadiness
+            - department
+            - resourceType
+            - adexResourceAPIs
+            - iudxResourceAPIs
+            - location
+            - dataDescriptor
+            - dataSample
+      example:
+        type: 'urn:dx:cat:Success'
+        title: 'Success'
+        detail: 'Success: Item created'
+        results:
+          '@context': "https://voc.iudx.org.in/"
+          type:
+            - "adex:DataBank"
+          id: "e27a1f6c-6a1b-45b8-a9f5-0c7424d1f0d1"
+          label: 'Weather insights for subdistricts'
+          description: 'Dataset providing weather information such as temperature and rainfall for subdistricts across a state.'
+          tags:
+            - environment
+            - weather
+            - rainfall
+            - temperature
+          provider: '{{UUID}}'
+          resourceGroup: '{{UUID}}'
+          resourceServer: '{{UUID}}'
+          accessPolicy: 'RESTRICTED'
+          organizationType: 'Private'
+          fileFormat: '.xlsx'
+          dataReadiness: 'More than 80%'
+          department: 'Department of IT, Electronics and Communication'
+          resourceType: 'MESSAGESTREAM'
+          adexResourceAPIs:
+            - 'TEMPORAL'
+            - 'ATTR'
+          iudxResourceAPIs:
+            - 'TEMPORAL'
+            - 'ATTR'
+          location:
+            type: 'Place'
+            address: 'Subdistrict HQ, Karnataka'
+            geometry:
+              type: 'Polygon'
+              coordinates:
+                - - [ 77.5946, 12.9716 ]
+                  - [ 77.5956, 12.9726 ]
+                  - [ 77.5966, 12.9736 ]
+                  - [ 77.5946, 12.9716 ]
+          dataDescriptor:
+            '@context': 'https://voc.iudx.org.in/'
+            type: [ 'adex:DataDescriptor' ]
+            dataDescriptorLabel: 'Subdistrict weather structure'
+            description: 'Structure defining data attributes for weather observations'
+            precipitation:
+              type: [ 'adex:Precipitation' ]
+              description: 'Rainfall in mm'
+              unitCode: 'MMT'
+              unitText: 'Millimeter'
+              dataSchema: 'float'
+          dataSample:
+            SomeKey: 'SomeValue'
+            observationDateTime: '2023-02-03T08:30:00+05:30'
+    successResponseForCreateAdexAppsEntity:
+      type: object
+      title: ADeX App Entity
+      description: An ADeX Potential Application item is successfully created
+      properties:
+        type:
+          type: string
+          description: |
+            URN type of the response indicating if the query was successful or if any errors have been triggered
+        title:
+          type: string
+          description: A human-readable title for the message response
+        detail:
+          type: string
+          description: Detailed description of the type or response
+        results:
+          type: object
+          properties:
+            '@context':
+              type: string
+              format: uri
+              description: JSON-LD context URI
+            id:
+              type: string
+              pattern: "^[a-zA-Z0-9\\-]{36}$"
+              description: Unique identifier of the application item
+            type:
+              type: array
+              items:
+                type: string
+              description: Type tags from the ADeX vocabulary
+            name:
+              type: string
+              maxLength: 512
+              pattern: "^[a-zA-Z0-9]([\\w-]*[a-zA-Z0-9 ])?$"
+              description: Name of the ADeX Application item
+            tags:
+              type: array
+              items:
+                type: string
+              description: Tags associated with the ADeX Application item
+            label:
+              type: string
+              maxLength: 512
+              description: User-friendly label for the application
+            description:
+              type: string
+              description: Detailed description of the application
+            organizationType:
+              type: string
+              description: Type of organization providing the application
+            department:
+              type: string
+              description: Department name
+            itemStatus:
+              type: string
+              enum: [ "ACTIVE", "INACTIVE" ]
+              description: Current status of the application
+            itemCreatedAt:
+              type: string
+              format: date-time
+              description: Creation timestamp of the application item
+          required:
+            - type
+            - name
+            - tags
+            - label
+            - description
+            - organizationType
+            - department
+      example:
+        type: 'urn:dx:cat:Success'
+        title: 'Success'
+        detail: 'Success: Item created'
+        results:
+          '@context': "https://voc.iudx.org.in/"
+          id: "d4fbe5b2-04b0-4a0a-a865-9fef27a5c48e"
+          type:
+            - "adex:Apps"
+          name: "agri-disease-detection"
+          tags:
+            - "ai"
+            - "ml"
+            - "crop"
+            - "disease"
+            - "learning"
+          label: "Crop Disease Detection App"
+          description: "An application for detecting crop diseases using AI-based models trained on infected leaf images."
+          organizationType: "Private"
+          department: "Agriculture and Co-operation"
+          itemStatus: "ACTIVE"
+          itemCreatedAt: "2024-01-05T02:09:10+0530"
     successResponseForUpdateOwnerEntity:
       type: object
       title: Owner Entity
@@ -5057,6 +5666,309 @@ components:
           itemStatus: "ACTIVE"
           itemCreatedAt: "2024-01-07T04:53:31+0530"
         detail: "Success: Item updated successfully"
+    successResponseForUpdateAIModelEntity:
+      type: object
+      title: AI Model Entity
+      description: AI Model item is successfully updated
+      properties:
+        type:
+          type: string
+          description: |
+            URN type of the response indicating if the query was successful or if any errors have been triggered
+        title:
+          type: string
+          description: A human-readable title for the message response
+        detail:
+          type: string
+          description: Detailed description of the type or response
+        results:
+          type: object
+          properties:
+            "@context":
+              type: string
+              format: uri
+              description: JSON-LD context URI
+            type:
+              type: array
+              items:
+                type: string
+              description: Type tags from the ADeX vocabulary
+            id:
+              type: string
+              pattern: "^[a-zA-Z0-9\\-]{36}$"
+              description: Unique identifier of the model item
+            name:
+              type: string
+              maxLength: 512
+              pattern: "^[a-zA-Z0-9]([\\w-]*[a-zA-Z0-9 ])?$"
+              description: Name of the model
+            provider:
+              type: string
+              maxLength: 36
+              pattern: "^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$"
+              description: UUID of the provider
+            tags:
+              type: array
+              items:
+                type: string
+              description: Tags related to the model
+            accessPolicy:
+              type: string
+              pattern: "^(RESTRICTED|OPEN|PII|restricted|open|pii)$"
+              description: Access policy for the model
+            label:
+              type: string
+              maxLength: 512
+              description: User-friendly label for the model
+            description:
+              type: string
+              description: Detailed description of the model
+            organizationType:
+              type: string
+              description: Type of organization providing the model
+            department:
+              type: string
+              description: Department name
+            modelType:
+              type: string
+              description: Type of model (e.g., ImageClassifier, TimeSeriesPredictor)
+            fileFormat:
+              type: string
+              description: File format of the model
+            itemStatus:
+              type: string
+              enum: [ "ACTIVE", "INACTIVE" ]
+              description: Current status of the model
+            itemCreatedAt:
+              type: string
+              format: date-time
+              description: Creation timestamp of the model item
+      required:
+        - type
+      example:
+        type: 'urn:dx:cat:Success'
+        title: 'Success'
+        detail: 'Success: Item updated successfully'
+        results:
+          "@context": "https://voc.iudx.org.in/"
+          type: [ "adex:AiModel" ]
+          id: "6e58c916-f6c1-448d-acea-756f3272bc57"
+          name: "ai-model-crop"
+          provider: "337545aa-1fa5-4ca0-bf3d-072144dec5b6"
+          tags:
+            - "ai"
+            - "ml"
+            - "model"
+            - "aimodel"
+            - "mlmodel"
+            - "ai-model"
+            - "ml-model"
+            - "machine"
+            - "learning"
+            - "machine learning"
+            - "training"
+            - "algorithm"
+          accessPolicy: "RESTRICTED"
+          label: "Test-Crop Disease Detection Model"
+          description: "An test AI model for detecting crop disease with the help of infected leaf images."
+          organizationType: "Private"
+          department: "Agriculture and Co-operation"
+          modelType: "ImageClassifier"
+          fileFormat: "ipynb"
+          itemStatus: "ACTIVE"
+          itemCreatedAt: "2024-01-07T04:53:31+0530"
+    successResponseForUpdateDataBankEntity:
+      type: object
+      title: DataBank Entity
+      description: DataBank item is successfully updated
+      properties:
+        type:
+          type: string
+          description: |
+            URN type of the response indicating if the query was successful or if any errors have been triggered
+        title:
+          description: A human-readable title for the message response
+        detail:
+          type: string
+          description: Detailed description of the type or response
+        results:
+          type: object
+          properties:
+            "@context":
+              type: string
+            type:
+              type: array
+              items:
+                type: string
+            name:
+              type: string
+            provider:
+              type: string
+            tags:
+              type: array
+              items:
+                type: string
+            accessPolicy:
+              type: string
+            resourceGroup:
+              type: string
+            organizationType:
+              type: string
+            fileFormat:
+              type: string
+            dataReadiness:
+              type: string
+            department:
+              type: string
+            resourceType:
+              type: string
+            adexResourceAPIs:
+              type: array
+              items:
+                type: string
+            location:
+              type: object
+            dataDescriptor:
+              type: object
+            dataSample:
+              type: object
+            id:
+              type: string
+            itemStatus:
+              type: string
+            itemCreatedAt:
+              type: string
+          required:
+            - type
+      required:
+        - type
+      example:
+        type: 'urn:dx:cat:Success'
+        title: 'Success'
+        results:
+          "@context": "https://voc.iudx.org.in/"
+          type:
+            - "adex:DataBank"
+          name: "subdistrict-weather-info"
+          provider: "337545aa-1fa5-4ca0-bf3d-072144dec5b6"
+          tags:
+            - "environment"
+            - "weather"
+            - "rainfall"
+            - "temperature"
+          accessPolicy: "RESTRICTED"
+          resourceGroup: "96bc97bf-504e-4306-bb49-99d77896cf1d"
+          organizationType: "Private"
+          fileFormat: ".xlsx"
+          dataReadiness: "More than 80%"
+          department: "Department of IT, Electronics and Communication"
+          resourceType: "MESSAGESTREAM"
+          adexResourceAPIs:
+            - "TEMPORAL"
+            - "ATTR"
+          location:
+            SomeKey: "SomeValue"
+          dataDescriptor:
+            SomeKey: "SomeValue"
+          dataSample:
+            SomeKey: "SomeValue"
+            observationDateTime: "2023-02-03T08:30:00+05:30"
+          id: "6e58c916-f6c1-448d-acea-756f3272bc57"
+          itemStatus: "ACTIVE"
+          itemCreatedAt: "2024-01-07T04:53:31+0530"
+        detail: "Success: Item updated successfully"
+    successResponseForUpdateAdexAppsEntity:
+      type: object
+      title: ADeX Potential Application Entity
+      description: ADeX Application metadata item is successfully updated
+      properties:
+        type:
+          type: string
+          description: |
+            URN type of the response indicating if the query was successful or if any errors have been triggered
+        title:
+          type: string
+          description: A human-readable title for the message response
+        detail:
+          type: string
+          description: Detailed description of the type or response
+        results:
+          type: object
+          properties:
+            "@context":
+              type: string
+              format: uri
+              description: JSON-LD context URI
+            type:
+              type: array
+              items:
+                type: string
+              description: Type tags from the ADeX vocabulary
+            id:
+              type: string
+              pattern: "^[a-zA-Z0-9\\-]{36}$"
+              description: Unique identifier of the application item
+            name:
+              type: string
+              maxLength: 512
+              pattern: "^[a-zA-Z0-9]([\\w-]*[a-zA-Z0-9 ])?$"
+              description: Name of the potential application
+            tags:
+              type: array
+              items:
+                type: string
+              description: Tags related to the application
+            label:
+              type: string
+              maxLength: 512
+              description: User-friendly label for the application
+            description:
+              type: string
+              description: Detailed description of the application
+            organizationType:
+              type: string
+              description: Type of organization providing the application
+            department:
+              type: string
+              description: Department name
+            itemStatus:
+              type: string
+              enum: [ "ACTIVE", "INACTIVE" ]
+              description: Current status of the application
+            itemCreatedAt:
+              type: string
+              format: date-time
+              description: Creation timestamp of the application item
+      required:
+        - type
+      example:
+        type: 'urn:dx:cat:Success'
+        title: 'Success'
+        detail: 'Success: Item updated successfully'
+        results:
+          "@context": "https://voc.iudx.org.in/"
+          type: [ "adex:Apps" ]
+          id: "8b95ab80-2aaf-4636-a65e-7f2563d0d371"
+          name: "some-name"
+          tags:
+            - "ai"
+            - "ml"
+            - "model"
+            - "aimodel"
+            - "mlmodel"
+            - "ai-model"
+            - "ml-model"
+            - "machine"
+            - "learning"
+            - "machine learning"
+            - "training"
+            - "algorithm"
+          label: "Test-Crop Disease Detection Model"
+          description: "An test potential application item for detecting crop disease with the help of infected leaf images."
+          organizationType: "Private"
+          department: "Agriculture and Co-operation"
+          itemStatus: "ACTIVE"
+          itemCreatedAt: "2024-01-07T04:53:31+0530"
     successResponseForGetOwnerEntity:
       type: object
       title: Owner Entity
@@ -5305,6 +6217,215 @@ components:
           itemStatus: "ACTIVE"
           itemCreatedAt: "2024-01-07T04:53:31+0530"
         detail: "Success: Item fetched Successfully"
+    successResponseForGetAIModelEntity:
+      type: object
+      title: AI Model Entity
+      description: AI Model item is successfully fetched
+      properties:
+        type:
+          type: string
+          description: |
+            URN type of the response indicating if the query was successful or if any errors have been triggered
+        title:
+          type: string
+          description: A human-readable title for the message response
+        detail:
+          type: string
+          description: Detailed description of the type or response
+        results:
+          type: object
+          properties:
+            "@context":
+              type: string
+              format: uri
+              description: JSON-LD context URI
+            type:
+              type: array
+              items:
+                type: string
+              description: Type tags from the ADeX vocabulary
+            id:
+              type: string
+              pattern: "^[a-zA-Z0-9\\-]{36}$"
+              description: Unique identifier of the model item
+            name:
+              type: string
+              pattern: "^[a-zA-Z0-9]([\\w-]*[a-zA-Z0-9 ])?$"
+              maxLength: 512
+              description: An explanation about the purpose of this instance.
+            provider:
+              type: string
+              pattern: "^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$"
+              maxLength: 36
+              description: UUID of the provider
+            tags:
+              type: array
+              items:
+                type: string
+              description: Tags describing the model
+            accessPolicy:
+              type: string
+              pattern: "^(RESTRICTED|OPEN|PII|restricted|open|pii)$"
+              description: Access policy for the model
+            label:
+              type: string
+              maxLength: 512
+              description: User-friendly label for the model
+            description:
+              type: string
+              description: Detailed description of the model
+            organizationType:
+              type: string
+              description: Type of organization providing the model
+            department:
+              type: string
+              description: Department name
+            modelType:
+              type: string
+              description: Type of model (e.g., ImageClassifier, TimeSeriesPredictor)
+            fileFormat:
+              type: string
+              description: File format of the model
+            itemStatus:
+              type: string
+              enum: [ "ACTIVE", "INACTIVE" ]
+              description: Current status of the model
+            itemCreatedAt:
+              type: string
+              format: date-time
+              description: Creation timestamp of the model item
+      required:
+        - type
+      example:
+        type: 'urn:dx:cat:Success'
+        title: 'Success'
+        detail: 'Success: Item fetched successfully'
+        results:
+          "@context": "https://voc.iudx.org.in/"
+          type:
+            - "adex:AiModel"
+          id: "6e58c916-f6c1-448d-acea-756f3272bc57"
+          name: "ai-model-crop"
+          provider: "8fe8d1dd-ae51-4ff8-b995-13bce85d9d88"
+          tags:
+            - "ai"
+            - "ml"
+            - "model"
+            - "aimodel"
+            - "mlmodel"
+            - "ai-model"
+            - "ml-model"
+            - "machine"
+            - "learning"
+            - "training"
+            - "algorithm"
+          accessPolicy: "RESTRICTED"
+          label: "Test-Crop Disease Detection Model"
+          description: "An test AI model for detecting crop disease with the help of infected leaf images."
+          organizationType: "Private"
+          department: "Agriculture and Co-operation"
+          modelType: "ImageClassifier"
+          fileFormat: "ipynb"
+          itemStatus: "ACTIVE"
+          itemCreatedAt: "2024-01-07T04:53:31+0530"
+    successResponseForGetDataBankEntity:
+      type: object
+      title: DataBank Entity
+      description: DataBank item is successfully fetched
+      properties:
+        type:
+          type: string
+          description: |
+            URN type of the response indicating if the query was successful or if any errors have been triggered
+        title:
+          description: A human-readable title for the message response
+        detail:
+          type: string
+          description: Detailed description of the type or response
+        results:
+          type: object
+          description: DataBank entity response body
+      required:
+        - type
+      example:
+        type: 'urn:dx:cat:Success'
+        title: 'Success'
+        results:
+          "@context": "https://voc.iudx.org.in/"
+          type:
+            - "adex:DataBank"
+          name: "subdistrict-weather-info"
+          provider: "337545aa-1fa5-4ca0-bf3d-072144dec5b6"
+          tags:
+            - "environment"
+            - "weather"
+            - "rainfall"
+            - "temperature"
+          accessPolicy: "RESTRICTED"
+          resourceGroup: "96bc97bf-504e-4306-bb49-99d77896cf1d"
+          organizationType: "Private"
+          fileFormat: ".xlsx"
+          dataReadiness: "More than 80%"
+          department: "Department of IT, Electronics and Communication"
+          resourceType: "MESSAGESTREAM"
+          adexResourceAPIs:
+            - "TEMPORAL"
+            - "ATTR"
+          location:
+            SomeKey: "SomeValue"
+          dataDescriptor:
+            SomeKey: "SomeValue"
+          dataSample:
+            SomeKey: "SomeValue"
+            observationDateTime: "2023-02-03T08:30:00+05:30"
+        detail: "Success: Item fetched Successfully"
+    successResponseForGetAdexAppsEntity:
+      type: object
+      title: ADeX Apps Entity
+      description: ADeX Potential Application item is successfully fetched
+      properties:
+        type:
+          type: string
+          description: |
+            URN type of the response indicating if the query was successful or if any errors have been triggered
+        title:
+          description: A human-readable title for the message response
+        detail:
+          type: string
+          description: Detailed description of the type or response
+        results:
+          type: object
+          description: ADeX Application entity response body
+      required:
+        - type
+      example:
+        type: 'urn:dx:cat:Success'
+        title: 'Success'
+        detail: 'Success: Item fetched Successfully'
+        results:
+          "@context": "https://voc.iudx.org.in/"
+          type:
+            - "adex:Apps"
+          name: "crop-disease-detector"
+          tags:
+            - "ai"
+            - "ml"
+            - "model"
+            - "aimodel"
+            - "mlmodel"
+            - "ai-model"
+            - "ml-model"
+            - "machine"
+            - "learning"
+            - "machine learning"
+            - "training"
+            - "algorithm"
+          label: "Crop Disease Detection Model"
+          description: "A model that helps detect crop diseases using infected leaf images."
+          organizationType: "Private"
+          department: "Agriculture and Co-operation"
+          itemStatus: "ACTIVE"
+          itemCreatedAt: "2024-06-15T10:25:00+05:30"
     successResponseForTagSearch:
       type: object
       title: Tag Search
@@ -6666,7 +7787,7 @@ components:
         type: urn:dx:cat:InvalidSchema
         title: Invalid Schema
         detail: Invalid Schema
-        results: []
+        results: [ ]
     errorInvalidLinks:
       type: object
       title: Response  - invalid links
@@ -7130,6 +8251,271 @@ components:
         resourceServer: '{{uuid}}'
         provider: '{uuid}}'
         resourceGroup: '{{uuid}}'
+    exampleEntityAIModel:
+      type: object
+      title: AI Model entity
+      description: An example AI model entity for first-time onboarding (without system-generated fields like itemCreatedAt or itemStatus)
+      properties:
+        '@context':
+          type: string
+          format: uri
+        id:
+          type: string
+          pattern: '^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$'
+        name:
+          type: string
+          pattern: '^[a-zA-Z0-9]([\\w-]*[a-zA-Z0-9 ])?$'
+          maxLength: 512
+        type:
+          type: array
+          items:
+            type: string
+        label:
+          type: string
+          maxLength: 512
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        provider:
+          type: string
+          pattern: '^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$'
+        accessPolicy:
+          type: string
+          pattern: '^(RESTRICTED|OPEN|PII|restricted|open|pii)$'
+        organizationType:
+          type: string
+          enum: [ 'Private', 'Government' ]
+        department:
+          type: string
+        modelType:
+          type: string
+        fileFormat:
+          type: string
+      required:
+        - type
+        - name
+        - label
+        - description
+        - tags
+        - provider
+        - accessPolicy
+        - organizationType
+        - department
+        - modelType
+        - fileFormat
+      example:
+        '@context': 'https://voc.iudx.org.in/'
+        id: '337545aa-1fa5-4ca0-bf3d-072144dec5b6'
+        type:
+          - 'adex:AiModel'
+        name: 'ai-model-crop'
+        label: 'Test-Crop Disease Detection Model'
+        description: 'A test AI model for detecting crop disease with the help of infected leaf images.'
+        tags:
+          - ai
+          - ml
+          - model
+          - ai-model
+          - ml-model
+          - machine
+          - learning
+          - machine learning
+          - training
+          - algorithm
+        provider: '337545aa-1fa5-4ca0-bf3d-072144dec5b6'
+        accessPolicy: 'RESTRICTED'
+        organizationType: 'Private'
+        department: 'Agriculture and Co-operation'
+        modelType: 'ImageClassifier'
+        fileFormat: 'ipynb'
+    exampleEntityDataBank:
+      type: object
+      title: Data Bank entity
+      description: An example entity without ID (For first time onboarding)
+      properties:
+        '@context':
+          type: string
+        id:
+          type: string
+          format: uuid
+        type:
+          type: array
+          items:
+            type: string
+        label:
+          type: string
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        provider:
+          type: string
+          format: uuid
+        accessPolicy:
+          type: string
+        resourceGroup:
+          type: string
+          format: uuid
+        organizationType:
+          type: string
+        fileFormat:
+          type: string
+        dataReadiness:
+          type: string
+        department:
+          type: string
+        resourceType:
+          type: string
+        adexResourceAPIs:
+          type: array
+          items:
+            type: string
+        iudxResourceAPIs:
+          type: array
+          items:
+            type: string
+        location:
+          type: object
+        dataDescriptor:
+          type: object
+        dataSample:
+          type: object
+      required:
+        - name
+        - type
+        - label
+        - description
+        - tags
+        - provider
+        - resourceGroup
+        - resourceServer
+        - accessPolicy
+        - organizationType
+        - fileFormat
+        - dataReadiness
+        - department
+        - resourceType
+        - adexResourceAPIs
+        - iudxResourceAPIs
+        - location
+        - dataDescriptor
+        - dataSample
+      example:
+        type:
+          - 'adex:DataBank'
+        label: 'Weather insights for subdistricts'
+        description: 'Dataset providing weather information such as temperature and rainfall for subdistricts across a state.'
+        tags:
+          - environment
+          - weather
+          - rainfall
+          - temperature
+        provider: '{{UUID}}'
+        resourceGroup: '{{UUID}}'
+        resourceServer: '{{UUID}}'
+        accessPolicy: 'RESTRICTED'
+        organizationType: 'Private'
+        fileFormat: '.xlsx'
+        dataReadiness: 'More than 80%'
+        department: 'Department of IT, Electronics and Communication'
+        resourceType: 'MESSAGESTREAM'
+        adexResourceAPIs:
+          - 'TEMPORAL'
+          - 'ATTR'
+        iudxResourceAPIs:
+          - 'TEMPORAL'
+          - 'ATTR'
+        location:
+          type: 'Place'
+          address: 'Subdistrict HQ, Karnataka'
+          geometry:
+            type: 'Polygon'
+            coordinates:
+              - - [ 77.5946, 12.9716 ]
+                - [ 77.5956, 12.9726 ]
+                - [ 77.5966, 12.9736 ]
+                - [ 77.5946, 12.9716 ]
+        dataDescriptor:
+          '@context': 'https://voc.iudx.org.in/'
+          type: [ 'adex:DataDescriptor' ]
+          dataDescriptorLabel: 'Subdistrict weather structure'
+          description: 'Structure defining data attributes for weather observations'
+          precipitation:
+            type: [ 'adex:Precipitation' ]
+            description: 'Rainfall in mm'
+            unitCode: 'MMT'
+            unitText: 'Millimeter'
+            dataSchema: 'float'
+        dataSample:
+          SomeKey: 'SomeValue'
+          observationDateTime: '2023-02-03T08:30:00+05:30'
+    exampleEntityAdexApps:
+      type: object
+      title: ADeX Apps entity
+      description: An example ADeX Apps entity for onboarding (without system-generated fields like itemCreatedAt or itemStatus)
+      properties:
+        '@context':
+          type: string
+          format: uri
+        id:
+          type: string
+          pattern: '^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$'
+        name:
+          type: string
+          pattern: '^[a-zA-Z0-9]([\\w-]*[a-zA-Z0-9 ])?$'
+          maxLength: 512
+        type:
+          type: array
+          items:
+            type: string
+        label:
+          type: string
+          maxLength: 512
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        organizationType:
+          type: string
+          enum: [ 'Private', 'Government' ]
+        department:
+          type: string
+      required:
+        - type
+        - name
+        - label
+        - description
+        - tags
+        - organizationType
+        - department
+      example:
+        '@context': 'https://voc.iudx.org.in/'
+        id: 'f2c6a437-8109-4a2c-8923-efc2a9e6df1d'
+        type:
+          - 'adex:Apps'
+        name: 'crop-disease-detector-app'
+        label: 'Crop Disease Detection Application'
+        description: 'A potential application designed to detect crop diseases from infected leaf images using AI/ML models.'
+        tags:
+          - ai
+          - ml
+          - model
+          - ai-model
+          - ml-model
+          - machine
+          - learning
+          - machine learning
+          - training
+          - algorithm
+        organizationType: 'Private'
+        department: 'Agriculture and Co-operation'
     unAuthorizedAccess:
       type: object
       title: Common to unauthorized access response
@@ -8330,30 +9716,30 @@ components:
               totalResources: 2
               instance_icon: "https://iudx-catalogue-assets.s3.ap-south-1.amazonaws.com/instances/icons/surat.jpg"
             resource:
-              -  instance: "surat"
-                 apdURL: "authdev.iudx.io"
-                 description: "TEST ITEM FOR APD verify. authdev.iudx.io is a dummy APD"
-                 label: "TEST ITEM FOR APD /verify TESTS"
-                 '@context': "https://voc.iudx.org.in/"
-                 resourceServer: "49cf5c76-09de-11ee-be56-0242ac120002"
-                 location:
-                   address: "Surat"
-                   type: "Place"
-                 accessPolicy: "SECURE"
-                 schema: "https://voc.iudx.org.in/TransitManagement"
-                 resourceId: "2d043bdb-fc62-4650-8426-dc72492cd621"
-              -  accessPolicy: "SECURE"
-                 apdURL: "acl-apd.iudx.io"
-                 resourceServer: "49cf5c76-09de-11ee-be56-0242ac120002"
-                 instance: "surat"
-                 description: "Realtime bus position information from Surat city public transit buses."
-                 label: "Surat Transit Realtime Position-UUID"
-                 '@context': "https://voc.iudx.org.in/"
-                 location:
-                   address: "Surat"
-                   type: "Place"
-                 schema: "https://voc.iudx.org.in/TransitManagement"
-                 resourceId: "83c2e5c2-3574-4e11-9530-2b1fbdfce832"
+              - instance: "surat"
+                apdURL: "authdev.iudx.io"
+                description: "TEST ITEM FOR APD verify. authdev.iudx.io is a dummy APD"
+                label: "TEST ITEM FOR APD /verify TESTS"
+                '@context': "https://voc.iudx.org.in/"
+                resourceServer: "49cf5c76-09de-11ee-be56-0242ac120002"
+                location:
+                  address: "Surat"
+                  type: "Place"
+                accessPolicy: "SECURE"
+                schema: "https://voc.iudx.org.in/TransitManagement"
+                resourceId: "2d043bdb-fc62-4650-8426-dc72492cd621"
+              - accessPolicy: "SECURE"
+                apdURL: "acl-apd.iudx.io"
+                resourceServer: "49cf5c76-09de-11ee-be56-0242ac120002"
+                instance: "surat"
+                description: "Realtime bus position information from Surat city public transit buses."
+                label: "Surat Transit Realtime Position-UUID"
+                '@context': "https://voc.iudx.org.in/"
+                location:
+                  address: "Surat"
+                  type: "Place"
+                schema: "https://voc.iudx.org.in/TransitManagement"
+                resourceId: "83c2e5c2-3574-4e11-9530-2b1fbdfce832"
     successResponseForPostDatasetWithTags:
       type: object
       title: Post Dataset With Tags

--- a/src/main/java/iudx/catalogue/server/apiserver/CrudApis.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/CrudApis.java
@@ -156,7 +156,8 @@ public final class CrudApis {
               handleItemCreation(routingContext, requestBody, response, jwtAuthenticationInfo);
             } else {
               if (itemType.equalsIgnoreCase(ITEM_TYPE_COS)
-                  || itemType.equalsIgnoreCase(ITEM_TYPE_OWNER)) {
+                  || itemType.equalsIgnoreCase(ITEM_TYPE_OWNER)
+                  || itemType.equalsIgnoreCase(ITEM_TYPE_APPS)) {
                 handleItemCreation(routingContext, requestBody, response, jwtAuthenticationInfo);
               } else if (itemType.equalsIgnoreCase(ITEM_TYPE_RESOURCE_SERVER)) {
                 handleItemCreation(routingContext, requestBody, response, jwtAuthenticationInfo);
@@ -415,7 +416,8 @@ public final class CrudApis {
                 handleItemDeletion(response, jwtAuthenticationInfo, requestBody, itemId);
               } else {
                 if (itemType.equalsIgnoreCase(ITEM_TYPE_COS)
-                    || itemType.equalsIgnoreCase(ITEM_TYPE_OWNER)) {
+                    || itemType.equalsIgnoreCase(ITEM_TYPE_OWNER)
+                    || itemType.equalsIgnoreCase(ITEM_TYPE_APPS)) {
                   handleItemDeletion(response, jwtAuthenticationInfo, requestBody, itemId);
                 } else if (itemType.equalsIgnoreCase(ITEM_TYPE_RESOURCE_SERVER)) {
                   handleItemDeletion(response, jwtAuthenticationInfo, requestBody, itemId);

--- a/src/main/java/iudx/catalogue/server/apiserver/ListApis.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/ListApis.java
@@ -88,6 +88,15 @@ public final class ListApis {
           case COS:
             type = ITEM_TYPE_COS;
             break;
+          case AI_MODEL:
+            type = ITEM_TYPE_AI_MODEL;
+            break;
+          case DATA_BANK:
+            type = ITEM_TYPE_DATA_BANK;
+            break;
+          case APPS:
+            type = ITEM_TYPE_APPS;
+            break;
           default:
             LOGGER.error("Fail: Invalid itemType:" + itemType);
             response

--- a/src/main/java/iudx/catalogue/server/authenticator/JwtAuthenticationServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/authenticator/JwtAuthenticationServiceImpl.java
@@ -82,6 +82,8 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
       case ITEM_TYPE_PROVIDER:
       case ITEM_TYPE_RESOURCE_GROUP:
       case ITEM_TYPE_RESOURCE:
+      case ITEM_TYPE_AI_MODEL:
+      case ITEM_TYPE_DATA_BANK:
         isValidAudience = serverUrl != null && serverUrl.equalsIgnoreCase(jwtData.getAud());
         break;
       case RATINGS:
@@ -206,7 +208,9 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
     boolean skipAdminCheck =
         itemType.equalsIgnoreCase("")
             || itemType.equalsIgnoreCase(ITEM_TYPE_RESOURCE_GROUP)
-            || itemType.equalsIgnoreCase(ITEM_TYPE_RESOURCE);
+            || itemType.equalsIgnoreCase(ITEM_TYPE_RESOURCE)
+            || itemType.equalsIgnoreCase(ITEM_TYPE_AI_MODEL)
+            || itemType.equalsIgnoreCase(ITEM_TYPE_DATA_BANK);
 
     jwtDecodeFuture
         .compose(
@@ -284,11 +288,14 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
       case ITEM_TYPE_OWNER:
       case ITEM_TYPE_COS:
       case ITEM_TYPE_RESOURCE_SERVER:
+      case ITEM_TYPE_APPS:
         isValidIid = type.equalsIgnoreCase("cos") && server.equalsIgnoreCase(issuer);
         break;
       case ITEM_TYPE_PROVIDER:
       case ITEM_TYPE_RESOURCE_GROUP:
       case ITEM_TYPE_RESOURCE:
+      case ITEM_TYPE_AI_MODEL:
+      case ITEM_TYPE_DATA_BANK:
         isValidIid = type.equalsIgnoreCase("rs") && server.equalsIgnoreCase(resourceServerRegUrl);
         break;
       default:

--- a/src/main/java/iudx/catalogue/server/authenticator/authorization/CosAdminAuthStrategy.java
+++ b/src/main/java/iudx/catalogue/server/authenticator/authorization/CosAdminAuthStrategy.java
@@ -46,6 +46,9 @@ public class CosAdminAuthStrategy implements AuthorizationStratergy {
     accessList.add(new AuthorizationRequest(PUT, api.getRouteItems(), ITEM_TYPE_RESOURCE_SERVER));
     accessList.add(
         new AuthorizationRequest(DELETE, api.getRouteItems(), ITEM_TYPE_RESOURCE_SERVER));
+    accessList.add(new AuthorizationRequest(POST, api.getRouteItems(), ITEM_TYPE_APPS));
+    accessList.add(new AuthorizationRequest(PUT, api.getRouteItems(), ITEM_TYPE_APPS));
+    accessList.add(new AuthorizationRequest(DELETE, api.getRouteItems(), ITEM_TYPE_APPS));
     accessList.add(new AuthorizationRequest(POST, api.getRouteInstance(), ITEM_TYPE_INSTANCE));
     accessList.add(new AuthorizationRequest(DELETE, api.getRouteInstance(), ITEM_TYPE_INSTANCE));
     accessList.add(new AuthorizationRequest(POST, api.getRouteMlayerInstance(), ""));

--- a/src/main/java/iudx/catalogue/server/authenticator/authorization/DelegateAuthStrategy.java
+++ b/src/main/java/iudx/catalogue/server/authenticator/authorization/DelegateAuthStrategy.java
@@ -1,6 +1,8 @@
 package iudx.catalogue.server.authenticator.authorization;
 
 import static iudx.catalogue.server.authenticator.authorization.Method.*;
+import static iudx.catalogue.server.util.Constants.ITEM_TYPE_AI_MODEL;
+import static iudx.catalogue.server.util.Constants.ITEM_TYPE_DATA_BANK;
 import static iudx.catalogue.server.util.Constants.ITEM_TYPE_RESOURCE;
 import static iudx.catalogue.server.util.Constants.ITEM_TYPE_RESOURCE_GROUP;
 
@@ -38,10 +40,16 @@ public class DelegateAuthStrategy implements AuthorizationStratergy {
     // /item access rules
     accessList.add(new AuthorizationRequest(POST, api.getRouteItems(), ITEM_TYPE_RESOURCE_GROUP));
     accessList.add(new AuthorizationRequest(POST, api.getRouteItems(), ITEM_TYPE_RESOURCE));
+    accessList.add(new AuthorizationRequest(POST, api.getRouteItems(), ITEM_TYPE_AI_MODEL));
+    accessList.add(new AuthorizationRequest(POST, api.getRouteItems(), ITEM_TYPE_DATA_BANK));
     accessList.add(new AuthorizationRequest(PUT, api.getRouteItems(), ITEM_TYPE_RESOURCE_GROUP));
     accessList.add(new AuthorizationRequest(PUT, api.getRouteItems(), ITEM_TYPE_RESOURCE));
+    accessList.add(new AuthorizationRequest(PUT, api.getRouteItems(), ITEM_TYPE_AI_MODEL));
+    accessList.add(new AuthorizationRequest(PUT, api.getRouteItems(), ITEM_TYPE_DATA_BANK));
     accessList.add(new AuthorizationRequest(DELETE, api.getRouteItems(), ITEM_TYPE_RESOURCE_GROUP));
     accessList.add(new AuthorizationRequest(DELETE, api.getRouteItems(), ITEM_TYPE_RESOURCE));
+    accessList.add(new AuthorizationRequest(DELETE, api.getRouteItems(), ITEM_TYPE_AI_MODEL));
+    accessList.add(new AuthorizationRequest(DELETE, api.getRouteItems(), ITEM_TYPE_DATA_BANK));
   }
 
   @Override

--- a/src/main/java/iudx/catalogue/server/authenticator/authorization/ProviderAuthStrategy.java
+++ b/src/main/java/iudx/catalogue/server/authenticator/authorization/ProviderAuthStrategy.java
@@ -1,6 +1,8 @@
 package iudx.catalogue.server.authenticator.authorization;
 
 import static iudx.catalogue.server.authenticator.authorization.Method.*;
+import static iudx.catalogue.server.util.Constants.ITEM_TYPE_AI_MODEL;
+import static iudx.catalogue.server.util.Constants.ITEM_TYPE_DATA_BANK;
 import static iudx.catalogue.server.util.Constants.ITEM_TYPE_RESOURCE;
 import static iudx.catalogue.server.util.Constants.ITEM_TYPE_RESOURCE_GROUP;
 
@@ -37,10 +39,16 @@ public class ProviderAuthStrategy implements AuthorizationStratergy {
     // /item access list
     accessList.add(new AuthorizationRequest(POST, api.getRouteItems(), ITEM_TYPE_RESOURCE_GROUP));
     accessList.add(new AuthorizationRequest(POST, api.getRouteItems(), ITEM_TYPE_RESOURCE));
+    accessList.add(new AuthorizationRequest(POST, api.getRouteItems(), ITEM_TYPE_AI_MODEL));
+    accessList.add(new AuthorizationRequest(POST, api.getRouteItems(), ITEM_TYPE_DATA_BANK));
     accessList.add(new AuthorizationRequest(PUT, api.getRouteItems(), ITEM_TYPE_RESOURCE_GROUP));
     accessList.add(new AuthorizationRequest(PUT, api.getRouteItems(), ITEM_TYPE_RESOURCE));
+    accessList.add(new AuthorizationRequest(PUT, api.getRouteItems(), ITEM_TYPE_AI_MODEL));
+    accessList.add(new AuthorizationRequest(PUT, api.getRouteItems(), ITEM_TYPE_DATA_BANK));
     accessList.add(new AuthorizationRequest(DELETE, api.getRouteItems(), ITEM_TYPE_RESOURCE_GROUP));
     accessList.add(new AuthorizationRequest(DELETE, api.getRouteItems(), ITEM_TYPE_RESOURCE));
+    accessList.add(new AuthorizationRequest(DELETE, api.getRouteItems(), ITEM_TYPE_AI_MODEL));
+    accessList.add(new AuthorizationRequest(DELETE, api.getRouteItems(), ITEM_TYPE_DATA_BANK));
   }
 
   @Override

--- a/src/main/java/iudx/catalogue/server/database/Constants.java
+++ b/src/main/java/iudx/catalogue/server/database/Constants.java
@@ -224,6 +224,7 @@ public class Constants {
   public static final String FILTER_QUERY = "{\"bool\":{\"filter\":[$1]}}";
   public static final String MATCH_QUERY = "{\"match\":{\"$1\":\"$2\"}}";
   public static final String TERM_QUERY = "{\"term\":{\"$1\":\"$2\"}}";
+  public static final String EXISTS_QUERY = "{\"exists\":{\"field\":\"$1\"}}";
   public static final String GET_RATING_DOCS =
       "{\"query\": {\"bool\": {\"must\": [ { \"match\": {\"$1\":\"$2\" } }, "
           + "{ \"match\": { \"status\": \"approved\" } } ] } } , "

--- a/src/main/java/iudx/catalogue/server/database/QueryDecoder.java
+++ b/src/main/java/iudx/catalogue/server/database/QueryDecoder.java
@@ -172,6 +172,11 @@ public final class QueryDecoder {
             JsonArray shouldQuery = new JsonArray();
             JsonArray valueArray = valueAttrs.getJsonArray(i);
             for (int j = 0; j < valueArray.size(); j++) {
+              if (ALL.equalsIgnoreCase(valueArray.getString(j))) {
+                String existsQuery = EXISTS_QUERY.replace("$1", propertyAttrs.getString(i));
+                shouldQuery.add(new JsonObject(existsQuery));
+                continue;
+              }
               String matchQuery;
               /* Attribute related queries using "match" and without the ".keyword" */
               if (propertyAttrs.getString(i).equals(TAGS)

--- a/src/main/java/iudx/catalogue/server/util/Constants.java
+++ b/src/main/java/iudx/catalogue/server/util/Constants.java
@@ -64,6 +64,9 @@ public class Constants {
   public static final String PROVIDER_USER_ID = "ownerUserId";
   public static final String RESOURCE_SERVER_URL = "resourceServerRegURL";
   public static final String COS_ITEM = "cos";
+  public static final String AI_MODEL = "aiModel";
+  public static final String DATA_BANK = "dataBank";
+  public static final String APPS = "apps";
   public static final String RESOURCETYPE = "resourceType";
 
 
@@ -76,10 +79,14 @@ public class Constants {
   public static final String ITEM_TYPE_COS = "iudx:COS";
   public static final String ITEM_TYPE_OWNER = "iudx:Owner";
   public static final String ITEM_TYPE_INSTANCE = "iudx:Instance";
+  public static final String ITEM_TYPE_AI_MODEL = "adex:AiModel";
+  public static final String ITEM_TYPE_DATA_BANK = "adex:DataBank";
+  public static final String ITEM_TYPE_APPS = "adex:Apps";
 
   public static final ArrayList<String> ITEM_TYPES =
       new ArrayList<String>(Arrays.asList(ITEM_TYPE_RESOURCE, ITEM_TYPE_RESOURCE_GROUP,
-          ITEM_TYPE_RESOURCE_SERVER, ITEM_TYPE_PROVIDER, ITEM_TYPE_COS, ITEM_TYPE_OWNER));
+          ITEM_TYPE_RESOURCE_SERVER, ITEM_TYPE_PROVIDER, ITEM_TYPE_COS, ITEM_TYPE_OWNER,
+          ITEM_TYPE_AI_MODEL, ITEM_TYPE_DATA_BANK, ITEM_TYPE_APPS));
 
   public static final String AGGREGATIONS = "aggregations";
   public static final String INSTANCE = "instance";

--- a/src/main/java/iudx/catalogue/server/validator/Constants.java
+++ b/src/main/java/iudx/catalogue/server/validator/Constants.java
@@ -48,5 +48,9 @@ public class Constants {
       "{\"query\":{\"bool\":{\"must\":[{"
           + "\"match\":{\"type\":\"iudx:Owner\"}},"
           + "{\"match\":{\"name.keyword\":\"$1\"}}]}}}";
+  public static final String APPS_ITEM_EXISTS_QUERY =
+      "{\"query\":{\"bool\":{\"must\":[{"
+          + "\"match\":{\"type\":\"adex:Apps\"}},"
+          + "{\"match\":{\"name.keyword\":\"$1\"}}]}}}";
   static final String FILTER_PATH = "?filter_path=took,hits.total.value,hits.hits._source";
 }

--- a/src/main/java/iudx/catalogue/server/validator/ValidatorServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/validator/ValidatorServiceImpl.java
@@ -213,7 +213,7 @@ public class ValidatorServiceImpl implements ValidatorService {
     } else if (itemType.equalsIgnoreCase(ITEM_TYPE_OWNER)) {
       validateOwnerItem(request, method, handler);
     } else if (itemType.equalsIgnoreCase(ITEM_TYPE_AI_MODEL)) {
-      validateAIModelItem(request, method, handler);
+      validateAiModelItem(request, method, handler);
     } else if (itemType.equalsIgnoreCase(ITEM_TYPE_APPS)) {
       validateAppsItem(request, method, handler);
     }
@@ -248,7 +248,7 @@ public class ValidatorServiceImpl implements ValidatorService {
         });
   }
 
-  private void validateAIModelItem(JsonObject request, String method,
+  private void validateAiModelItem(JsonObject request, String method,
                                    Handler<AsyncResult<JsonObject>> handler) {
     validateId(request, handler, isUacInstance);
     if (!isUacInstance && !request.containsKey(ID)) {

--- a/src/main/resources/iudx/catalogue/server/validator/adexAiModelItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/adexAiModelItemSchema.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "http://example.com/model-metadata.schema.json",
+  "type": "object",
+  "title": "Adex AI Model Metadata Schema",
+  "description": "Schema for ADeX AI/ML model metadata.",
+  "default": {},
+  "examples": [
+    {
+      "type": [
+        "adex:AiModel"
+      ],
+      "name": "ai-model-crop",
+      "provider": "337545aa-1fa5-4ca0-bf3d-072144dec5b6",
+      "tags": [
+        "ai", "ml", "model", "aimodel", "mlmodel",
+        "ai-model", "ml-model", "machine", "learning",
+        "machine learning", "training", "algorithm"
+      ],
+      "accessPolicy": "RESTRICTED",
+      "label": "Test-Crop Disease Detection Model",
+      "description": "An test AI model for detecting crop disease with the help of infected leaf images.",
+      "organizationType": "Private",
+      "department": "Agriculture and Co-operation",
+      "modelType": "ImageClassifier",
+      "fileFormat": "ipynb"
+    }
+  ],
+  "required": [
+    "name",
+    "type",
+    "label",
+    "description",
+    "tags",
+    "provider",
+    "accessPolicy",
+    "organizationType",
+    "department",
+    "modelType",
+    "fileFormat"
+  ],
+  "properties": {
+    "name": {
+      "$id": "#/properties/name",
+      "type": "string",
+      "title": "The name schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": "",
+      "examples": ["SomePlace"],
+      "maxLength": 512,
+      "pattern": "^[a-zA-Z0-9]([\\w-]*[a-zA-Z0-9 ])?$"
+    },
+    "id": {
+      "$id": "#/properties/id",
+      "type": "string",
+      "title": "The id schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": "",
+      "examples": [
+        "8b95ab80-2aaf-4636-a65e-7f2563d0d371"
+      ],
+      "maxLength": 36,
+      "pattern": "^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$"
+    },
+    "type": {
+      "$id": "#/properties/type",
+      "type": "array",
+      "title": "The type schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": [],
+      "examples": [
+        [
+          "adex:AiModel"
+        ]
+      ],
+      "additionalItems": true,
+      "items": {
+        "$id": "#/properties/type/items",
+        "anyOf": [
+          {
+            "$id": "#/properties/type/items/anyOf/0",
+            "type": "string",
+            "title": "The first anyOf schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": "",
+            "examples": [
+              "adex:AiModel"
+            ]
+          }
+        ]
+      }
+    },
+    "provider": {
+      "$id": "#/properties/provider",
+      "type": "string",
+      "title": "The provider schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": "",
+      "examples": ["8b95ab80-2aaf-4636-a65e-7f2563d0d371"],
+      "maxLength": 36,
+      "pattern": "^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$"
+    },
+    "tags": {
+      "$id": "#/properties/tags",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "title": "The tags schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": ""
+    },
+    "accessPolicy": {
+      "$id": "#/properties/accessPolicy",
+      "type": "string",
+      "title": "The access policy schema",
+      "default": "",
+      "examples": ["SECURE", "pii"],
+      "pattern": "^(RESTRICTED|OPEN|PII|restricted|open|pii)$"
+    },
+    "label": {
+      "$id": "#/properties/label",
+      "type": "string",
+      "title": "The label schema",
+      "description": "User-friendly label for the model",
+      "default": "",
+      "examples": ["SomeLabel"],
+      "maxLength": 512
+    },
+    "description": {
+      "type": "string",
+      "title": "The description schema",
+      "description": "Detailed description of the model"
+    },
+    "organizationType": {
+      "type": "string",
+      "title": "The organizationType schema",
+      "description": "Type of organization providing the model",
+      "examples": ["Private", "Government"]
+    },
+    "department": {
+      "type": "string",
+      "title": "The department schema",
+      "description": "Department name"
+    },
+    "modelType": {
+      "type": "string",
+      "title": "The modelType schema",
+      "description": "Type of model (e.g., ImageClassifier, TimeSeriesPredictor)"
+    },
+    "fileFormat": {
+      "type": "string",
+      "title": "The fileFormat schema",
+      "description": "File format of the model",
+      "examples": ["ipynb", "pkl", "onnx"]
+    },
+    "itemStatus": {
+      "type": "string",
+      "title": "The itemStatus schema",
+      "description": "Current status of the model",
+      "enum": ["ACTIVE", "INACTIVE"]
+    },
+    "itemCreatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "title": "The itemCreatedAt schema",
+      "description": "Creation timestamp of the model item"
+    },
+    "@context": {
+      "type": "string",
+      "title": "The @context schema",
+      "description": "JSON-LD context URI",
+      "format": "uri"
+    }
+  },
+  "additionalProperties": true
+}

--- a/src/main/resources/iudx/catalogue/server/validator/adexAppsItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/adexAppsItemSchema.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "http://example.com/apps-metadata.schema.json",
+  "type": "object",
+  "title": "Adex Potential Applications Metadata Schema",
+  "description": "Schema for ADeX Apps model metadata.",
+  "default": {},
+  "examples": [
+    {
+      "type": [
+        "adex:Apps"
+      ],
+      "name": "SomeName",
+      "tags": [
+        "ai", "ml", "model", "aimodel", "mlmodel",
+        "ai-model", "ml-model", "machine", "learning",
+        "machine learning", "training", "algorithm"
+      ],
+      "label": "Test-Crop Disease Detection Model",
+      "description": "An test potential application item for detecting crop disease with the help of infected leaf images.",
+      "organizationType": "Private",
+      "department": "Agriculture and Co-operation"
+    }
+  ],
+  "required": [
+    "name",
+    "type",
+    "tags",
+    "label",
+    "description",
+    "organizationType",
+    "department"
+  ],
+  "properties": {
+    "name": {
+      "$id": "#/properties/name",
+      "type": "string",
+      "title": "The name schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": "",
+      "examples": ["SomePlace"],
+      "maxLength": 512,
+      "pattern": "^[a-zA-Z0-9]([\\w-]*[a-zA-Z0-9 ])?$"
+    },
+    "id": {
+      "$id": "#/properties/id",
+      "type": "string",
+      "title": "The id schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": "",
+      "examples": [
+        "8b95ab80-2aaf-4636-a65e-7f2563d0d371"
+      ],
+      "maxLength": 36,
+      "pattern": "^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$"
+    },
+    "type": {
+      "$id": "#/properties/type",
+      "type": "array",
+      "title": "The type schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": [],
+      "examples": [
+        [
+          "adex:Apps"
+        ]
+      ],
+      "additionalItems": true,
+      "items": {
+        "$id": "#/properties/type/items",
+        "anyOf": [
+          {
+            "$id": "#/properties/type/items/anyOf/0",
+            "type": "string",
+            "title": "The first anyOf schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": "",
+            "examples": [
+              "adex:Apps"
+            ]
+          }
+        ]
+      }
+    },
+    "tags": {
+      "$id": "#/properties/tags",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "title": "The tags schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": ""
+    },
+    "label": {
+      "type": "string",
+      "title": "The label schema",
+      "description": "User-friendly label for the model",
+      "maxLength": 512
+    },
+    "description": {
+      "type": "string",
+      "title": "The description schema",
+      "description": "Detailed description of the model"
+    },
+    "organizationType": {
+      "type": "string",
+      "title": "The organizationType schema",
+      "description": "Type of organization providing the model",
+      "examples": ["Private", "Government"]
+    },
+    "department": {
+      "type": "string",
+      "title": "The department schema",
+      "description": "Department name"
+    },
+    "itemStatus": {
+      "type": "string",
+      "title": "The itemStatus schema",
+      "description": "Current status of the model",
+      "enum": ["ACTIVE", "INACTIVE"]
+    },
+    "itemCreatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "title": "The itemCreatedAt schema",
+      "description": "Creation timestamp of the model item"
+    },
+    "@context": {
+      "type": "string",
+      "title": "The @context schema",
+      "description": "JSON-LD context URI",
+      "format": "uri"
+    }
+  },
+  "additionalProperties": true
+}

--- a/src/main/resources/iudx/catalogue/server/validator/adexDataBankResourceItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/adexDataBankResourceItemSchema.json
@@ -1,0 +1,386 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "http://example.com/databank-resource-metadata.schema.json",
+  "type": "object",
+  "title": "Data Bank Resource Metadata Schema",
+  "description": "The root schema comprises the entire JSON document",
+  "default": {},
+  "examples": [
+    {
+      "name": "subdistrict-weather-info",
+      "type": [
+        "adex:DataBank"
+      ],
+      "label": "SomeLabel",
+      "description": "SomeDescription",
+      "tags": ["environment", "weather", "rainfall", "temperature"],
+      "provider": "337545aa-1fa5-4ca0-bf3d-072144dec5b6",
+      "resourceGroup": "96bc97bf-504e-4306-bb49-99d77896cf1d",
+      "resourceServer": "",
+      "accessPolicy": "RESTRICTED",
+      "organizationType": "Private",
+      "fileFormat": ".xlsx",
+      "dataReadiness": "More than 80%",
+      "department": "Department of IT, Electronics and Communication",
+      "resourceType": "MESSAGESTREAM",
+      "adexResourceAPIs": [
+        "TEMPORAL",
+        "ATTR"
+      ],
+      "iudxResourceAPIs": [
+        "ATTR"
+      ],
+      "location": {
+        "SomeKey": "SomeValue"
+      },
+      "dataDescriptor": {
+        "SomeKey": "SomeValue"
+      },
+      "dataSample": {
+        "SomeKey": "SomeValue",
+        "observationDateTime": "2023-02-03T08:30:00+05:30"
+      }
+    }
+  ],
+  "required": [
+    "name",
+    "type",
+    "label",
+    "description",
+    "tags",
+    "provider",
+    "resourceGroup",
+    "resourceServer",
+    "accessPolicy",
+    "organizationType",
+    "fileFormat",
+    "dataReadiness",
+    "department",
+    "resourceType",
+    "adexResourceAPIs",
+    "iudxResourceAPIs",
+    "location",
+    "dataDescriptor",
+    "dataSample"
+  ],
+  "properties": {
+    "name": {
+      "$id": "#/properties/name",
+      "type": "string",
+      "title": "The name schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": "",
+      "examples": ["SomePlace"],
+      "maxLength": 512,
+      "pattern": "^[a-zA-Z0-9]([\\w-]*[a-zA-Z0-9 ])?$"
+    },
+    "id": {
+      "$id": "#/properties/id",
+      "type": "string",
+      "title": "The id schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": "",
+      "examples": [
+        "8b95ab80-2aaf-4636-a65e-7f2563d0d371"
+      ],
+      "maxLength": 36,
+      "pattern": "^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$"
+    },
+    "type": {
+      "$id": "#/properties/type",
+      "type": "array",
+      "title": "The type schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": [],
+      "examples": [
+        [
+          "adex:DataBank"
+        ]
+      ],
+      "additionalItems": true,
+      "items": {
+        "$id": "#/properties/type/items",
+        "anyOf": [
+          {
+            "$id": "#/properties/type/items/anyOf/0",
+            "type": "string",
+            "title": "The first anyOf schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": "",
+            "examples": [
+              "adex:DataBank"
+            ]
+          }
+        ]
+      }
+    },
+    "tags": {
+      "$id": "#/properties/tags",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "title": "The tags schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": ""
+    },
+    "provider": {
+      "$id": "#/properties/provider",
+      "type": "string",
+      "title": "The provider schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": "",
+      "examples": ["8b95ab80-2aaf-4636-a65e-7f2563d0d371"],
+      "maxLength": 36,
+      "pattern": "^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$"
+    },
+    "resourceGroup": {
+      "$id": "#/properties/resourceGroup",
+      "type": "string",
+      "title": "The resourceGroup schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": "",
+      "examples": ["8b95ab80-2aaf-4636-a65e-7f2563d0d371"],
+      "maxLength": 36,
+      "pattern": "^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$"
+    },
+    "resourceServer": {
+      "$id": "#/properties/resourceServer",
+      "type": "string",
+      "title": "The resourceServer schema",
+      "description": "An explanation about the purpose of this instance.",
+      "default": "",
+      "examples": [
+        "8b95ab80-2aaf-4636-a65e-7f2563d0d371"
+      ],
+      "maxLength": 36,
+      "pattern": "^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$"
+    },
+    "accessPolicy": {
+      "$id": "#/properties/accessPolicy",
+      "type": "string",
+      "title": "The access policy schema",
+      "default": "",
+      "examples": ["RESTRICTED", "PII"],
+      "pattern": "^(RESTRICTED|OPEN|PII|restricted|open|pii)$"
+    },
+    "label": {
+      "type": "string",
+      "title": "The label schema",
+      "maxLength": 512
+    },
+    "description": {
+      "type": "string",
+      "title": "The description schema"
+    },
+    "organizationType": {
+      "type": "string",
+      "title": "The organizationType schema"
+    },
+    "fileFormat": {
+      "type": "string",
+      "title": "The fileFormat schema"
+    },
+    "dataReadiness": {
+      "type": "string",
+      "title": "The dataReadiness schema"
+    },
+    "department": {
+      "type": "string",
+      "title": "The department schema"
+    },
+    "resourceType": {
+      "type": "string",
+      "title": "The resourceType schema",
+      "enum": ["MESSAGESTREAM", "STATIC", "API"]
+    },
+    "adexResourceAPIs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "iudxResourceAPIs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "location": {
+      "type": "object",
+      "title": "The location schema",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "Place"
+        },
+        "address": {
+          "type": "string"
+        },
+        "geometry": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "Polygon"
+            },
+            "coordinates": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              }
+            }
+          },
+          "required": ["type", "coordinates"]
+        }
+      },
+      "required": ["type", "address", "geometry"]
+    },
+    "dataDescriptor": {
+      "type": "object",
+      "title": "The dataDescriptor schema",
+      "description": "Definition of the structure and types of observed data attributes.",
+      "properties": {
+        "@context": { "type": "string" },
+        "type": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "dataDescriptorLabel": { "type": "string" },
+        "description": { "type": "string" },
+        "districtCode": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "array", "items": { "type": "string" } },
+            "description": { "type": "string" },
+            "dataSchema": { "type": "string" }
+          }
+        },
+        "subDistrictCode": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "array", "items": { "type": "string" } },
+            "description": { "type": "string" },
+            "dataSchema": { "type": "string" }
+          }
+        },
+        "precipitation": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "array", "items": { "type": "string" } },
+            "description": { "type": "string" },
+            "unitCode": { "type": "string" },
+            "unitText": { "type": "string" },
+            "dataSchema": { "type": "string" }
+          }
+        },
+        "airTemperature": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "array", "items": { "type": "string" } },
+            "description": { "type": "string" },
+            "maxOverTime": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "array", "items": { "type": "string" } },
+                "description": { "type": "string" },
+                "dataSchema": { "type": "string" },
+                "unitCode": { "type": "string" },
+                "unitText": { "type": "string" }
+              }
+            },
+            "minOverTime": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "array", "items": { "type": "string" } },
+                "description": { "type": "string" },
+                "dataSchema": { "type": "string" },
+                "unitCode": { "type": "string" },
+                "unitText": { "type": "string" }
+              }
+            }
+          }
+        },
+        "relativeHumidity": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "array", "items": { "type": "string" } },
+            "description": { "type": "string" },
+            "maxOverTime": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "array", "items": { "type": "string" } },
+                "description": { "type": "string" },
+                "dataSchema": { "type": "string" },
+                "unitCode": { "type": "string" },
+                "unitText": { "type": "string" }
+              }
+            },
+            "minOverTime": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "array", "items": { "type": "string" } },
+                "description": { "type": "string" },
+                "dataSchema": { "type": "string" },
+                "unitCode": { "type": "string" },
+                "unitText": { "type": "string" }
+              }
+            }
+          }
+        },
+        "observationDateTime": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "array", "items": { "type": "string" } },
+            "description": { "type": "string" },
+            "dataSchema": { "type": "string" }
+          }
+        }
+      }
+    },
+    "dataSample": {
+      "type": "object",
+      "properties": {
+        "districtCode": { "type": ["string", "number"] },
+        "subDistrictCode": { "type": ["string", "number"] },
+        "precipitation": { "type": "number" },
+        "airTemperature": {
+          "type": "object",
+          "properties": {
+            "maxOverTime": { "type": "number" },
+            "minOverTime": { "type": "number" }
+          }
+        },
+        "relativeHumidity": {
+          "type": "object",
+          "properties": {
+            "maxOverTime": { "type": "number" },
+            "minOverTime": { "type": "number" }
+          }
+        },
+        "observationDateTime": { "type": "string", "format": "date-time" }
+      }
+    },
+    "itemStatus": {
+      "type": "string",
+      "enum": ["ACTIVE", "INACTIVE"]
+    },
+    "itemCreatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "@context": {
+      "type": "string",
+      "format": "uri"
+    }
+  },
+  "additionalProperties": true
+}

--- a/src/test/java/iudx/catalogue/server/apiserver/integrationtests/crudApisIT/CrudAPIsIT.java
+++ b/src/test/java/iudx/catalogue/server/apiserver/integrationtests/crudApisIT/CrudAPIsIT.java
@@ -28,6 +28,9 @@ public class CrudAPIsIT {
     public static String provider_id;
     public static String resource_group_id;
     public static String resource_item_id;
+    public static String ai_model_item_id;
+    public static String data_bank_resource_item_id;
+    public static String adex_app_id;
 
     // Helper method to check item existence
     private boolean itemExists(String id) {
@@ -61,7 +64,7 @@ public class CrudAPIsIT {
         jsonPayload.put("@context", "https://voc.iudx.org.in/");
         JsonArray typeArray = new JsonArray().add("iudx:Owner");
         jsonPayload.put("type", typeArray);
-        jsonPayload.put("name", "OwnerItemPM18");
+        jsonPayload.put("name", "OwnerItemForTest");
         jsonPayload.put("description", "testing owner item creation through integration tests");
 
         Response response= given()
@@ -102,7 +105,7 @@ public class CrudAPIsIT {
         JsonObject jsonPayload = new JsonObject()
                 .put("@context", "https://voc.iudx.org.in/")
                 .put("type",new JsonArray().add("iudx:COS"))
-                .put("name", "iudxCOSPM18")
+                .put("name", "CosItem4Test")
                 .put("owner", owner_id)
                 .put("description", "testing COS item creation through integration tests")
                 .put("cosURL","cat-test.iudx.io")
@@ -128,6 +131,55 @@ public class CrudAPIsIT {
 
     @Test
     @Order(3)
+    @DisplayName("testing create ADEX Apps item - 201")
+    void createAdexAppsItem() {
+
+        // Optional delay if needed, similar to COS item creation
+        try {
+            Thread.sleep(2000); // 2 seconds delay
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        JsonObject jsonPayload = new JsonObject()
+            .put("type", new JsonArray().add("adex:Apps"))
+            .put("name", "AppsItem4Test")
+            .put("tags", new JsonArray()
+                .add("ai")
+                .add("ml")
+                .add("agriculture")
+                .add("planthealth")
+                .add("diseasedetection")
+                .add("deep-learning")
+                .add("cnn")
+                .add("image-classification")
+                .add("leaf-analysis"))
+            .put("label", "Crop Disease Detection using AI")
+            .put("description", "An AI-based application that detects diseases in crops by analyzing images of leaves. It uses deep learning models to identify symptoms and suggest treatments.")
+            .put("organizationType", "Private")
+            .put("department", "Agriculture and Co-operation");
+
+        Response response = given()
+            .contentType("application/json")
+            .header("token", cosAdminToken)
+            .body(jsonPayload.toString())
+            .when()
+            .post("/item/")
+            .then()
+            .statusCode(201)
+            .body("type", is("urn:dx:cat:Success"))
+            .body("title", is("Success"))
+            .body("detail", equalTo("Success: Item created"))
+            .body("results.id", notNullValue())
+            .extract()
+            .response();
+
+        // Extract and store the created item ID if needed
+        adex_app_id = response.path("results.id");
+    }
+
+    @Test
+    @Order(4)
     @DisplayName("testing the creation of DX Resource Server Item Entity - 201")
     void createDXResourceServerItemEntity() {
         LOGGER.debug("cos_id from resource server item creation..."+cos_id);
@@ -146,7 +198,7 @@ public class CrudAPIsIT {
         JsonObject jsonPayload = new JsonObject()
                 .put("@context", "https://voc.iudx.org.in/")
                 .put("type", new JsonArray().add("iudx:ResourceServer"))
-                .put("name", "IudxResourceServerPM")
+                .put("name", "ResourceServer4Test")
                 .put("description", "Multi tenanted IUDX resource server for integration tests")
                 .put("tags",new JsonArray().add("IUDX").add("Resource").add("Server").add("Platform"))
                 .put("cos", cos_id)
@@ -195,7 +247,7 @@ public class CrudAPIsIT {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     @DisplayName("testing create DX Provider item - 201")
     void createDXProviderItem() {
         LOGGER.debug("resource server id from provider item creation..."+resource_server_id);
@@ -250,7 +302,54 @@ public class CrudAPIsIT {
     }
 
     @Test
-    @Order(5)
+    @Order(6)
+    @DisplayName("testing create DX AI Model Item Entity - 201")
+    void createDXAIModelItemEntity() {
+        LOGGER.debug("provider id check..."+provider_id);
+        // Introduce a delay
+        try {
+            Thread.sleep(2000); // 2 seconds delay
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        // Check if provider item exists before creating DX Resource Group item
+        if (!itemExists(provider_id)) {
+            LOGGER.warn("provider item does not exist. Retrying...");
+        }
+
+        JsonObject jsonPayload = new JsonObject()
+            .put("type", new JsonArray().add("adex:AiModel"))
+            .put("name", "AiModelForTest")
+            .put("description", "ai model item for the postman collection")
+            .put("label", "ai model item for test only")
+            .put("tags", new JsonArray().add("ai").add("crop").add("crop disease")
+                .add("disease detection").add("ai model"))
+            .put("provider", provider_id)
+            .put("accessPolicy", "RESTRICTED")
+            .put("organizationType", "Private")
+            .put("department", "Agriculture and Co-operation")
+            .put("modelType", "ImageClassifier")
+            .put("fileFormat", "ipynb");
+        Response response = given()
+            .contentType("application/json")
+            .header("token", token)
+            .body(jsonPayload.toString())
+            .when()
+            .post("/item/")
+            .then()
+            .statusCode(201)
+            .body("type", is("urn:dx:cat:Success"))
+            .body("title", is("Success"))
+            .body("detail", equalTo("Success: Item created"))
+            .body("results.id", notNullValue())
+            .extract()
+            .response();
+        // Extract the generated ID from the response
+        ai_model_item_id = response.path("results.id");
+    }
+
+    @Test
+    @Order(7)
     @DisplayName("testing create DX Resource Group Item Entity - 201")
     void createDXResourceGroupItemEntity() {
         LOGGER.debug("provider id before check..."+provider_id);
@@ -274,7 +373,7 @@ public class CrudAPIsIT {
         JsonObject jsonPayload = new JsonObject()
                 .put("@context", "https://voc.iudx.org.in/")
                 .put("type", new JsonArray().add("iudx:ResourceGroup").add("iudx:IssueReporting"))
-                .put("name", "ResourceGroupPM19")
+                .put("name", "ResourceGroupForTest")
                 .put("description", "resource group item for the postman collection")
                 .put("tags", new JsonArray().add("swachhata").add("complaints").add("construction material").add("requests"))
                 .put("provider", provider_id);
@@ -297,7 +396,7 @@ public class CrudAPIsIT {
     }
 
     @Test
-    @Order(6)
+    @Order(8)
     @DisplayName("testing create DX Resource Item - 201")
     void createDXResourceItem() {
         LOGGER.debug("from DX RS item..."+resource_server_id +" "+provider_id+" "+resource_group_id);
@@ -328,7 +427,7 @@ public class CrudAPIsIT {
         JsonObject jsonPayload = new JsonObject()
                 .put("@context", "https://voc.iudx.org.in/")
                 .put("type", new JsonArray().add("iudx:Resource").add("iudx:PointOfInterest"))
-                .put("name", "ResourceItemPM19")
+                .put("name", "ResourceItemForTest")
                 .put("label", "item for test only")
                 .put("description", "resource item for the postman collection")
                 .put("tags", new JsonArray().add("swachhata").add("complaints").add("construction material").add("requests"))
@@ -357,7 +456,78 @@ public class CrudAPIsIT {
     }
 
     @Test
-    @Order(7)
+    @Order(9)
+    @DisplayName("testing create DX Data Bank Resource Item Entity - 201")
+    void createDXDataBankResourceItemEntity() {
+        LOGGER.debug("from DX Data Bank RS item..."
+            + resource_server_id + " " + provider_id + " " + resource_group_id);
+
+        // Introduce a delay
+        try {
+            Thread.sleep(2000); // 2 seconds delay
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        // Check if RS item exists before creating DX Resource item
+        if (!itemExists(resource_server_id)) {
+            LOGGER.debug("Inside RS id check..");
+            LOGGER.warn("item does not exist. Retrying...");
+            // Add retry logic or handle the situation accordingly
+        }
+        if (!itemExists(provider_id)) {
+            LOGGER.debug("Inside provider id check..");
+            LOGGER.warn("item does not exist. Retrying...");
+            // Add retry logic or handle the situation accordingly
+        }
+        if (!itemExists(resource_group_id)) {
+            LOGGER.debug("Inside RS group id check..");
+            LOGGER.warn("item does not exist. Retrying...");
+            // Add retry logic or handle the situation accordingly
+        }
+
+        JsonObject jsonPayload = new JsonObject()
+            .put("@context", "https://voc.iudx.org.in/")
+            .put("type", new JsonArray().add("adex:DataBank"))
+            .put("name", "DataBankItem4Test")
+            .put("description", "ai model item for the postman collection")
+            .put("label", "ai model item for test only")
+            .put("tags", new JsonArray().add("ai").add("crop").add("crop disease")
+                .add("disease detection").add("ai model"))
+            .put("resourceServer", resource_server_id)
+            .put("provider", provider_id)
+            .put("resourceGroup", resource_group_id)
+            .put("accessPolicy", "RESTRICTED")
+            .put("organizationType", "Private")
+            .put("department", "Agriculture and Co-operation")
+            .put("dataReadiness", "More than 80%")
+            .put("resourceType", "MESSAGESTREAM")
+            .put("iudxResourceAPIs", new JsonArray().add("ATTR"))
+            .put("adexResourceAPIs", new JsonArray().add("TEMPORAL").add("ATTR"))
+            .put("location", new JsonObject().put("type", "Place").put("address", "Khammam, " +
+                "Telanagana").put("geometry", new JsonObject().put("coordinates", new JsonArray())))
+            .put("dataDescriptor", "sample descriptor")
+            .put("dataSample", "sample data")
+            .put("fileFormat", "xlsx");
+        Response response = given()
+            .contentType("application/json")
+            .header("token", token)
+            .body(jsonPayload.toString())
+            .when()
+            .post("/item/")
+            .then()
+            .statusCode(201)
+            .body("type", is("urn:dx:cat:Success"))
+            .body("title", is("Success"))
+            .body("detail", equalTo("Success: Item created"))
+            .body("results.id", notNullValue())
+            .extract()
+            .response();
+        // Extract the generated ID from the response
+        data_bank_resource_item_id = response.path("results.id");
+    }
+
+    @Test
+    @Order(10)
     @DisplayName("testing create a DX Resource item - 400")
     void createDXResourceItem400() {
         JsonObject jsonPayload = new JsonObject()
@@ -387,7 +557,7 @@ public class CrudAPIsIT {
     }
 
     @Test
-    @Order(8)
+    @Order(11)
     @DisplayName("testing create DX Entity - 400")
     void createDXEntity400() {
         LOGGER.info("owner_id: "+owner_id);
@@ -413,7 +583,7 @@ public class CrudAPIsIT {
     }
 
     @Test
-    @Order(9)
+    @Order(12)
     @DisplayName("testing create DX Entity - 400 Invalid UUID")
     void createDXEntityInvalidUUID400() {
         JsonObject jsonPayload = new JsonObject()
@@ -450,7 +620,7 @@ public class CrudAPIsIT {
     }
 
     @Test
-    @Order(10)
+    @Order(13)
     @DisplayName("testing create DX Entity - 401 Invalid Credentials")
     void createDXEntityInvalidCredentials() {
         JsonObject jsonPayload = new JsonObject()
@@ -482,13 +652,13 @@ public class CrudAPIsIT {
      */
 
     @Test
-    @Order(11)
+    @Order(14)
     @DisplayName("testing update owner item - 200")
     void updateOwnerItem() {
         JsonObject jsonPayload = new JsonObject()
                 .put("@context", "https://voc.iudx.org.in/")
                 .put("type", new JsonArray().add("iudx:Owner"))
-                .put("name", "iudxOwnerPM18")
+                .put("name", "OwnerItemForTest")
                 .put("description", "testing the owner id updation through integration tests")
                 .put("id", owner_id);
         Response response = given()
@@ -506,13 +676,13 @@ public class CrudAPIsIT {
     }
 
     @Test
-    @Order(12)
+    @Order(15)
     @DisplayName("testing update COS item - 200")
     void updateCOSItem() {
         JsonObject jsonPayload = new JsonObject()
                 .put("@context", "https://voc.iudx.org.in/")
                 .put("type", new JsonArray().add("iudx:COS"))
-                .put("name", "IudxCosPM18")
+                .put("name", "CosItem4Test")
                 .put("owner", owner_id)
                 .put("id", cos_id)
                 .put("description", "COS item for postman collection")
@@ -534,13 +704,49 @@ public class CrudAPIsIT {
     }
 
     @Test
-    @Order(13)
+    @Order(16)
+    @DisplayName("testing update ADEX Apps item - 200")
+    void updateAdexAppsItem() {
+        LOGGER.info("Updating ADEX Apps item with ID: " + adex_app_id);
+
+        JsonObject updatePayload = new JsonObject()
+            .put("type", new JsonArray().add("adex:Apps"))
+            .put("name", "AppsItem4Test")
+            .put("id", adex_app_id)
+            .put("tags", new JsonArray()
+                .add("ai")
+                .add("ml")
+                .add("agriculture")
+                .add("planthealth")
+                .add("diseasedetection")
+                .add("deep-learning")
+                .add("cnn")
+                .add("image-classification")
+                .add("leaf-analysis"))
+            .put("organizationType", "Private")
+            .put("department", "Agriculture and Co-operation")
+            .put("description", "UPDATED: AI app for crop disease detection using advanced CNN models.")
+            .put("label", "Updated Crop Disease Detection");
+
+        given()
+            .contentType("application/json")
+            .header("token", cosAdminToken)
+            .body(updatePayload.toString())
+            .when()
+            .put("/item/")
+            .then()
+            .statusCode(200)
+            .body("type", is("urn:dx:cat:Success"));
+    }
+
+    @Test
+    @Order(17)
     @DisplayName("testing update DX Resource Server Item - 200")
-    void updateDXResourceItem(){
+    void updateDXResourceServerItem(){
         JsonObject jsonPayload = new JsonObject()
                 .put("@context", "https://voc.iudx.org.in/")
                 .put("type", new JsonArray().add("iudx:ResourceServer"))
-                .put("name", "ResourceServerPM19")
+                .put("name", "ResourceServer4Test")
                 .put("id", resource_server_id)
                 .put("description", "Multi tenanted IUDX resource server for postman collection")
                 .put("tags", new JsonArray().add("IUDX").add("Resource").add("Server").add("Platform"))
@@ -591,13 +797,13 @@ public class CrudAPIsIT {
     }
 
     @Test
-    @Order(14)
+    @Order(18)
     @DisplayName("testing updation of DX Provider Item - 200")
     void updateDXProviderItem() {
         JsonObject jsonPayload = new JsonObject()
                 .put("@context", "https://voc.iudx.org.in/")
                 .put("type", new JsonArray().add("iudx:Provider"))
-                .put("name", "ProviderPM19")
+                .put("name", "ProviderForTest")
                 .put("id", provider_id)
                 .put("resourceServer", resource_server_id)
                 .put("description", "provider for the postman collection")
@@ -628,13 +834,45 @@ public class CrudAPIsIT {
     }
 
     @Test
-    @Order(15)
+    @Order(19)
+    @DisplayName("testing updation of DX AI Model Item - 200")
+    void updateDXAiModelItem() {
+        JsonObject jsonPayload = new JsonObject()
+            .put("@context", "https://voc.iudx.org.in/")
+            .put("type", new JsonArray().add("adex:AiModel"))
+            .put("name", "AiModelForTest")
+            .put("id", ai_model_item_id)
+            .put("description", "update ai model item for the postman collection")
+            .put("label", "ai model item for test only")
+            .put("tags", new JsonArray().add("ai").add("crop").add("crop disease")
+                .add("disease detection").add("ai model"))
+            .put("provider", provider_id)
+            .put("accessPolicy", "RESTRICTED")
+            .put("organizationType", "Private")
+            .put("department", "Agriculture and Co-operation")
+            .put("modelType", "ImageClassifier")
+            .put("fileFormat", "ipynb");
+        Response response = given()
+            .contentType("application/json")
+            .header("token", token)
+            .body(jsonPayload.toString())
+            .when()
+            .put("/item/")
+            .then()
+            .statusCode(200)
+            .body("type", is("urn:dx:cat:Success"))
+            .extract()
+            .response();
+    }
+
+    @Test
+    @Order(20)
     @DisplayName("testing updation of DX Resource Group Item - 200")
     void updateDXResourceGroupItem() {
         JsonObject jsonPayload = new JsonObject()
                 .put("@context", "https://voc.iudx.org.in/")
                 .put("type", new JsonArray().add("iudx:ResourceGroup").add("iudx:IssueReporting"))
-                .put("name", "ResourceGroupPM19")
+                .put("name", "ResourceGroupForTest")
                 .put("id", resource_group_id)
                 .put("description", "resource group item for the postman collection")
                 .put("tags", new JsonArray().add("swachhata").add("complaints").add("construction material").add("requests"))
@@ -652,13 +890,13 @@ public class CrudAPIsIT {
                 .response();
     }
     @Test
-    @Order(16)
+    @Order(21)
     @DisplayName("testing updation of DX Resource Item - 200")
     void updateDXResourceItem200() {
         JsonObject jsonPayload = new JsonObject()
                 .put("@context", "https://voc.iudx.org.in/")
                 .put("type", new JsonArray().add("iudx:Resource").add("iudx:PointOfInterest"))
-                .put("name", "ResourceItemPM19")
+                .put("name", "ResourceItemForTest")
                 .put("id", resource_item_id)
                 .put("label", "item for test only")
                 .put("description", "resource item for the postman collection")
@@ -681,9 +919,50 @@ public class CrudAPIsIT {
                 .extract()
                 .response();
     }
+    @Test
+    @Order(22)
+    @DisplayName("testing updation of DX Resource Item - 200")
+    void updateDXDataBankItem200() {
+        JsonObject jsonPayload = new JsonObject()
+            .put("@context", "https://voc.iudx.org.in/")
+            .put("type", new JsonArray().add("adex:DataBank"))
+            .put("name", "DataBankItem4Test")
+            .put("id", data_bank_resource_item_id)
+            .put("description", "ai model item for the postman collection")
+            .put("label", "ai model item for test only")
+            .put("tags", new JsonArray().add("ai").add("crop").add("crop disease")
+                .add("disease detection").add("ai model"))
+            .put("resourceServer", resource_server_id)
+            .put("provider", provider_id)
+            .put("resourceGroup", resource_group_id)
+            .put("accessPolicy", "RESTRICTED")
+            .put("organizationType", "Private")
+            .put("department", "Agriculture and Co-operation")
+            .put("dataReadiness", "More than 80%")
+            .put("resourceType", "MESSAGESTREAM")
+            .put("iudxResourceAPIs", new JsonArray().add("ATTR"))
+            .put("adexResourceAPIs", new JsonArray().add("TEMPORAL").add("ATTR"))
+            .put("location", new JsonObject().put("type", "Place").put("address", "Khammam, " +
+                "Telanagana").put("geometry", new JsonObject().put("coordinates", new JsonArray())))
+            .put("dataDescriptor", "sample")
+            .put("dataSample", "sample")
+            .put("fileFormat", "xlsx");
+
+        Response response = given()
+            .contentType("application/json")
+            .header("token", token)
+            .body(jsonPayload.toString())
+            .when()
+            .put("/item/")
+            .then()
+            .statusCode(200)
+            .body("type", is("urn:dx:cat:Success"))
+            .extract()
+            .response();
+    }
 
     @Test
-    @Order(17)
+    @Order(23)
     @DisplayName("testing updation of DX Entity - 400")
     void updateDXEntity400() {
         JsonObject jsonPayload = new JsonObject()
@@ -708,7 +987,7 @@ public class CrudAPIsIT {
     }
 
     @Test
-    @Order(18)
+    @Order(24)
     @DisplayName("testing updation of DX Entity - 400 (Invalid links)")
     void updateDXEntity400InvalidLinks() {
         JsonObject jsonPayload = new JsonObject()
@@ -738,7 +1017,7 @@ public class CrudAPIsIT {
     }
 
     @Test
-    @Order(19)
+    @Order(25)
     @DisplayName("testing update DX Entity - 401 Invalid Credentials")
     void updateDXEntityInvalidCredentials() {
         JsonObject jsonPayload = new JsonObject()
@@ -765,7 +1044,7 @@ public class CrudAPIsIT {
     }
 
     @Test
-    @Order(20)
+    @Order(26)
     @DisplayName("testing update DX Entity - 404 Not Found")
     void updateDXEntityNotFound() {
         JsonObject jsonPayload = new JsonObject()
@@ -800,7 +1079,7 @@ public class CrudAPIsIT {
      * DX Provider items, DX Resource Group items, and DX Resource items.
      */
     @Test
-    @Order(21)
+    @Order(27)
     @DisplayName("testing get DX Entity by ID- 200 Success")
     void getDXEntityByID() {
         LOGGER.info("owner_id: "+owner_id);
@@ -817,7 +1096,7 @@ public class CrudAPIsIT {
     }
 
     @Test
-    @Order(22)
+    @Order(28)
     @DisplayName("testing get DX Entity by ID - 404 Not Found")
     void getDXEntityNotFound() {
         Response response = given()
@@ -833,7 +1112,7 @@ public class CrudAPIsIT {
     }
 
     @Test
-    @Order(23)
+    @Order(29)
     @DisplayName("testing get DX Entity by ID - 400 Invalid UUID")
     void getDXEntityInvalidUUID() {
         Response response = given()
@@ -849,7 +1128,7 @@ public class CrudAPIsIT {
     }
 
     @Test
-    @Order(24)
+    @Order(30)
     @DisplayName("testing list Type (Data Model) given Resource Id - 200 type of item")
     void getDXEntityTypeRS() {
         Response response = given()
@@ -867,7 +1146,7 @@ public class CrudAPIsIT {
     }
 
     @Test
-    @Order(25)
+    @Order(31)
     @DisplayName("testing list Type (Data Model) given Resource Group Id - 200 type of item")
     void getDXEntityRSGroup() {
         Response response = given()
@@ -890,7 +1169,7 @@ public class CrudAPIsIT {
      * DX Provider items, DX Resource Group items, and DX Resource items.
      */
     @Test
-    @Order(26)
+    @Order(32)
     @DisplayName("testing delete a Resource Item DX Entity - 200")
     void DeleteRSItemDXEntity() {
         Response response = given()
@@ -906,7 +1185,7 @@ public class CrudAPIsIT {
                 .response();
     }
     @Test
-    @Order(27)
+    @Order(33)
     @DisplayName("testing delete a Resource Group DX Entity - 200")
     void DeleteRSGroupDXEntity() {
         Response response = given()
@@ -922,7 +1201,39 @@ public class CrudAPIsIT {
                 .response();
     }
     @Test
-    @Order(28)
+    @Order(34)
+    @DisplayName("testing delete ai model DX Entity - 200")
+    void DeleteAiModelDXEntity() {
+        Response response = given()
+            .param("id", ai_model_item_id)
+            .header("token", token)
+            .contentType("application/json")
+            .when()
+            .delete("/item")
+            .then()
+            .statusCode(200)
+            .body("type", is("urn:dx:cat:Success"))
+            .extract()
+            .response();
+    }
+    @Test
+    @Order(35)
+    @DisplayName("testing delete data bank resource DX Entity - 200")
+    void DeleteDataBankDXEntity() {
+        Response response = given()
+            .param("id", data_bank_resource_item_id)
+            .header("token", token)
+            .contentType("application/json")
+            .when()
+            .delete("/item")
+            .then()
+            .statusCode(200)
+            .body("type", is("urn:dx:cat:Success"))
+            .extract()
+            .response();
+    }
+    @Test
+    @Order(36)
     @DisplayName("testing delete a Provider DX Entity - 200")
     void DeleteProviderDXEntity() {
         Response response = given()
@@ -938,7 +1249,7 @@ public class CrudAPIsIT {
                 .response();
     }
     @Test
-    @Order(29)
+    @Order(37)
     @DisplayName("testing delete a Resource Server DX Entity - 200")
     void DeleteResourceServerDXEntity() {
         Response response = given()
@@ -953,24 +1264,9 @@ public class CrudAPIsIT {
                 .extract()
                 .response();
     }
+
     @Test
-    @Order(31)
-    @DisplayName("testing delete a Owner DX Entity - 200")
-    void DeleteOwnerDXEntity() {
-        Response response = given()
-                .param("id", owner_id)
-                .header("token", cosAdminToken)
-                .contentType("application/json")
-                .when()
-                .delete("/item")
-                .then()
-                .statusCode(200)
-                .body("type", is("urn:dx:cat:Success"))
-                .extract()
-                .response();
-    }
-    @Test
-    @Order(30)
+    @Order(38)
     @DisplayName("testing delete a COS DX Entity - 200")
     void DeleteCosDXEntity() {
         Response response = given()
@@ -985,8 +1281,42 @@ public class CrudAPIsIT {
                 .extract()
                 .response();
     }
+
     @Test
-    @Order(32)
+    @Order(39)
+    @DisplayName("testing delete a Owner DX Entity - 200")
+    void DeleteOwnerDXEntity() {
+        Response response = given()
+            .param("id", owner_id)
+            .header("token", cosAdminToken)
+            .contentType("application/json")
+            .when()
+            .delete("/item")
+            .then()
+            .statusCode(200)
+            .body("type", is("urn:dx:cat:Success"))
+            .extract()
+            .response();
+    }
+
+    @Test
+    @Order(40)
+    @DisplayName("testing delete ADEX Apps item - 200")
+    void deleteAdexAppsItem() {
+        LOGGER.info("Deleting ADEX Apps item with ID: " + adex_app_id);
+
+        given()
+            .contentType("application/json")
+            .header("token", cosAdminToken)
+            .when()
+            .delete("/item")
+            .then()
+            .statusCode(200)
+            .body("type", is("urn:dx:cat:Success"));
+    }
+
+    @Test
+    @Order(41)
     @DisplayName("testing delete a DX Entity - 404 Not Found")
     void DeleteDXEntity404() {
         Response response = given()
@@ -1002,7 +1332,7 @@ public class CrudAPIsIT {
                 .response();
     }
     @Test
-    @Order(33)
+    @Order(42)
     @DisplayName("testing delete a DX Entity - 400 Invalid UUID")
     void DeleteDXEntityInvalidUUID() {
         Response response = given()
@@ -1018,7 +1348,7 @@ public class CrudAPIsIT {
                 .response();
     }
     @Test
-    @Order(34)
+    @Order(43)
     @DisplayName("testing delete a DX Entity - 401 Invalid credentials")
     void DeleteDXEntityInvalidCred() {
         Response response = given()


### PR DESCRIPTION
##  Summary

This PR introduces support for the **AI Sandbox** feature in the catalogue server. It includes schema additions, updates to validation and authorization logic, and changes to relevant APIs.

---

##  Changes Made

- **Schema Files Added:**
  - `adexAiModelItemSchema.json`
  - `adexAppsItemSchema.json`
  - `adexDataBankResourceItemSchema.json`

- **OpenAPI Specification:**
  - Updated `docs/openapi.yaml` to include new item types and request formats.

- **API Layer Updates:**
  - `CrudApis.java`
  - `ListApis.java`

- **Authentication Strategy Updates:**
  - `CosAdminAuthStrategy.java`
  - `DelegateAuthStrategy.java`
  - `ProviderAuthStrategy.java`
  - `JwtAuthenticationServiceImpl.java`

- **Validation & Utility Changes:**
  - `ValidatorServiceImpl.java`
  - `QueryDecoder.java`
  - `Constants.java` across:
    - `database`, `util`, `validator` packages

##  Tests

- Modified integration test:
  - `CrudAPIsIT.java`
- Additional test coverage can be added in follow-up PRs if needed.

---