### PR TITLE
fuzzy search added

### DIFF
--- a/src/main/java/iudx/catalogue/server/database/Constants.java
+++ b/src/main/java/iudx/catalogue/server/database/Constants.java
@@ -76,6 +76,10 @@ public class Constants {
       "{ \"geo_shape\": { \"$4\": { \"shape\": { \"type\": \"$1\", \"coordinates\": $2 },"
           + " \"relation\": \"$3\" } } }";
   public static final String TEXT_QUERY = "{\"query_string\":{\"query\":\"$1\"}}";
+  public static final String TEXT_QUERY_FUZZY =
+          "{\"multi_match\":{\"fields\":[\"label\",\"tags\",\"description\"],\"query\":\"$1\","
+                  + "\"fuzziness\":\"AUTO\",\"minimum_should_match\":\"100%\",\"operator\":\"and\"}}";
+
   public static final String GET_DOC_QUERY =
       "{\"_source\":[$2],\"query\":{\"term\":{\"id.keyword\":\"$1\"}}}";
 
@@ -223,6 +227,7 @@ public class Constants {
   public static final String MUST_QUERY = "{\"bool\":{\"must\":$1}}";
   public static final String FILTER_QUERY = "{\"bool\":{\"filter\":[$1]}}";
   public static final String MATCH_QUERY = "{\"match\":{\"$1\":\"$2\"}}";
+  public static final String FUZZY_MATCH_QUERY = "{ \"match\": { \"$1\": { \"query\": \"$2\", \"fuzziness\": \"AUTO\", \"operator\": \"or\" }}}";
   public static final String TERM_QUERY = "{\"term\":{\"$1\":\"$2\"}}";
   public static final String GET_RATING_DOCS =
       "{\"query\": {\"bool\": {\"must\": [ { \"match\": {\"$1\":\"$2\" } }, "

--- a/src/main/java/iudx/catalogue/server/database/Constants.java
+++ b/src/main/java/iudx/catalogue/server/database/Constants.java
@@ -78,7 +78,7 @@ public class Constants {
   public static final String TEXT_QUERY = "{\"query_string\":{\"query\":\"$1\"}}";
   public static final String TEXT_QUERY_FUZZY =
           "{\"multi_match\":{\"fields\":[\"label\",\"tags\",\"description\"],\"query\":\"$1\","
-                  + "\"fuzziness\":\"AUTO\",\"minimum_should_match\":\"100%\",\"operator\":\"and\"}}";
+          +  "\"fuzziness\":\"AUTO\",\"minimum_should_match\":\"100%\",\"operator\":\"and\"}}";
 
   public static final String GET_DOC_QUERY =
       "{\"_source\":[$2],\"query\":{\"term\":{\"id.keyword\":\"$1\"}}}";
@@ -227,7 +227,8 @@ public class Constants {
   public static final String MUST_QUERY = "{\"bool\":{\"must\":$1}}";
   public static final String FILTER_QUERY = "{\"bool\":{\"filter\":[$1]}}";
   public static final String MATCH_QUERY = "{\"match\":{\"$1\":\"$2\"}}";
-  public static final String FUZZY_MATCH_QUERY = "{ \"match\": { \"$1\": { \"query\": \"$2\", \"fuzziness\": \"AUTO\", \"operator\": \"or\" }}}";
+  public static final String FUZZY_MATCH_QUERY = "{ \"match\": { \"$1\": { \"query\": "
+          + "\"$2\", \"fuzziness\": \"AUTO\", \"operator\": \"or\" }}}";
   public static final String TERM_QUERY = "{\"term\":{\"$1\":\"$2\"}}";
   public static final String GET_RATING_DOCS =
       "{\"query\": {\"bool\": {\"must\": [ { \"match\": {\"$1\":\"$2\" } }, "

--- a/src/main/java/iudx/catalogue/server/database/QueryDecoder.java
+++ b/src/main/java/iudx/catalogue/server/database/QueryDecoder.java
@@ -144,8 +144,7 @@ public final class QueryDecoder {
       if (request.containsKey(Q_VALUE) && !request.getString(Q_VALUE).isBlank()) {
         /* constructing db queries */
         String textAttr = request.getString(Q_VALUE);
-        if(request.containsKey(FUZZY) && request.getString(FUZZY).equals("true"))
-        {
+        if (request.containsKey(FUZZY) && request.getString(FUZZY).equals("true")) {
           String textQuery = TEXT_QUERY_FUZZY.replace("$1", textAttr);
 
           mustQuery.add(new JsonObject(textQuery));
@@ -191,8 +190,7 @@ public final class QueryDecoder {
                                         .replace("$2", valueArray.getString(j));
                 shouldQuery.add(new JsonObject(matchQuery));
 
-                if (request.containsKey(FUZZY) && request.getString(FUZZY).equals("true"))
-                {
+                if (request.containsKey(FUZZY) && request.getString(FUZZY).equals("true")) {
                   if (propertyAttrs.getString(i).equals(TAGS)
                           || propertyAttrs.getString(i).equals(DESCRIPTION_ATTR)) {
                     matchQuery =
@@ -216,10 +214,9 @@ public final class QueryDecoder {
                                           .replace("$2", valueArray.getString(j));
                 }
                 shouldQuery.add(new JsonObject(matchQuery));
-                if (request.containsKey(FUZZY) && request.getString(FUZZY).equals("true"))
-                {
+                if (request.containsKey(FUZZY) && request.getString(FUZZY).equals("true")) {
                   if (propertyAttrs.getString(i).equals(LABEL)
-                          ||propertyAttrs.getString(i).equals(INSTANCE)) {
+                          || propertyAttrs.getString(i).equals(INSTANCE)) {
                     matchQuery =
                             FUZZY_MATCH_QUERY
                                     .replace("$1", propertyAttrs.getString(i))

--- a/src/main/java/iudx/catalogue/server/database/QueryDecoder.java
+++ b/src/main/java/iudx/catalogue/server/database/QueryDecoder.java
@@ -190,15 +190,14 @@ public final class QueryDecoder {
                                         .replace("$2", valueArray.getString(j));
                 shouldQuery.add(new JsonObject(matchQuery));
 
-                if (request.containsKey(FUZZY) && request.getString(FUZZY).equals("true")) {
-                  if (propertyAttrs.getString(i).equals(TAGS)
-                          || propertyAttrs.getString(i).equals(DESCRIPTION_ATTR)) {
-                    matchQuery =
-                            FUZZY_MATCH_QUERY
-                                    .replace("$1", propertyAttrs.getString(i))
-                                    .replace("$2", valueArray.getString(j));
-                    shouldQuery.add(new JsonObject(matchQuery));
-                  }
+                if (request.containsKey(FUZZY)
+                        && "true".equals(request.getString(FUZZY))
+                        && (TAGS.equals(propertyAttrs.getString(i))
+                        || DESCRIPTION_ATTR.equals(propertyAttrs.getString(i)))) {
+                  matchQuery = FUZZY_MATCH_QUERY
+                          .replace("$1", propertyAttrs.getString(i))
+                          .replace("$2", valueArray.getString(j));
+                  shouldQuery.add(new JsonObject(matchQuery));
                 }
 
                 /* Attribute related queries using "match" and with the ".keyword" */
@@ -214,16 +213,15 @@ public final class QueryDecoder {
                                           .replace("$2", valueArray.getString(j));
                 }
                 shouldQuery.add(new JsonObject(matchQuery));
-                if (request.containsKey(FUZZY) && request.getString(FUZZY).equals("true")) {
-                  if (propertyAttrs.getString(i).equals(LABEL)
-                          || propertyAttrs.getString(i).equals(INSTANCE)) {
-                    matchQuery =
-                            FUZZY_MATCH_QUERY
-                                    .replace("$1", propertyAttrs.getString(i))
-                                    .replace("$2", valueArray.getString(j));
-                    shouldQuery.add(new JsonObject(matchQuery));
-                  }
+                if ("true".equals(request.getString(FUZZY))
+                        && (LABEL.equals(propertyAttrs.getString(i))
+                        || INSTANCE.equals(propertyAttrs.getString(i)))) {
+                  matchQuery = FUZZY_MATCH_QUERY
+                          .replace("$1", propertyAttrs.getString(i))
+                          .replace("$2", valueArray.getString(j));
+                  shouldQuery.add(new JsonObject(matchQuery));
                 }
+
               }
             }
             mustQuery.add(new JsonObject(SHOULD_QUERY.replace("$1", shouldQuery.toString())));

--- a/src/main/java/iudx/catalogue/server/util/Constants.java
+++ b/src/main/java/iudx/catalogue/server/util/Constants.java
@@ -154,6 +154,8 @@ public class Constants {
   public static final String RESOURCE_COUNT = "resourceCount";
   public static final String PROVIDER_COUNT = "providerCount";
   public static final String RESOURCE_GROUP_COUNT = "resourceGroupCount";
+  public static final String FUZZY = "fuzzy";
+
 
   /** HTTP Methods. */
   public static final String REQUEST_GET = "GET";

--- a/src/test/resources/iudx-catalogue-server-v5.5.0.postman_collection.json
+++ b/src/test/resources/iudx-catalogue-server-v5.5.0.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "adbf46da-9eae-4bd2-8cd3-e325de262a91",
+		"_postman_id": "7ac9a51c-e2a6-4514-a471-3d1623406128",
 		"name": "iudx-catalogue-server v5.5.0",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "27217689"
@@ -10341,6 +10341,275 @@
 										{
 											"key": "offset",
 											"value": "1010101"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Fuzzy Search",
+					"item": [
+						{
+							"name": "Text Fuzzy Search on \"paid parking\"",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Check response header\", function () {\r",
+											"    pm.response.to.have.header(\"Content-Type\",\"application/json\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Check response body\", function () {    \r",
+											"    const body = pm.response.json();\r",
+											"    pm.expect(body).to.have.property(\"type\", \"urn:dx:cat:Success\");\r",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{host}}{{base}}/search?q=pard painking&fuzzy=true",
+									"host": [
+										"{{host}}{{base}}"
+									],
+									"path": [
+										"search"
+									],
+									"query": [
+										{
+											"key": "q",
+											"value": "pard painking"
+										},
+										{
+											"key": "fuzzy",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Text Fuzzy Search on Resource Item",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Check response header\", function () {\r",
+											"    pm.response.to.have.header(\"Content-Type\",\"application/json\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Check response body\", function () {    \r",
+											"    const body = pm.response.json();\r",
+											"    pm.expect(body).to.have.property(\"type\", \"urn:dx:cat:Success\");\r",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{host}}{{base}}/search?q=pard painking&fuzzy=true&property=\"[type]\"&value=\"[[iudx:Resource]]\"",
+									"host": [
+										"{{host}}{{base}}"
+									],
+									"path": [
+										"search"
+									],
+									"query": [
+										{
+											"key": "q",
+											"value": "pard painking"
+										},
+										{
+											"key": "fuzzy",
+											"value": "true"
+										},
+										{
+											"key": "property",
+											"value": "\"[type]\""
+										},
+										{
+											"key": "value",
+											"value": "\"[[iudx:Resource]]\""
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Attribute Fuzzy Search",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{host}}{{base}}/search?property=\"[instance]\"&fuzzy=true&value=\"[[suwat]]\"",
+									"host": [
+										"{{host}}{{base}}"
+									],
+									"path": [
+										"search"
+									],
+									"query": [
+										{
+											"key": "property",
+											"value": "\"[instance]\""
+										},
+										{
+											"key": "fuzzy",
+											"value": "true"
+										},
+										{
+											"key": "value",
+											"value": "\"[[suwat]]\""
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Multi-Attribute Fuzzy Search",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Check response header\", function () {\r",
+											"    pm.response.to.have.header(\"Content-Type\",\"application/json\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Check response body\", function () {    \r",
+											"    const body = pm.response.json();\r",
+											"    pm.expect(body).to.have.property(\"type\", \"urn:dx:cat:Success\");\r",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{host}}{{base}}/search?property=\"[tags,description]\"&value=\"[[floing, current level],[Sensor]]\"&fuzzy=true",
+									"host": [
+										"{{host}}{{base}}"
+									],
+									"path": [
+										"search"
+									],
+									"query": [
+										{
+											"key": "property",
+											"value": "\"[tags,description]\""
+										},
+										{
+											"key": "value",
+											"value": "\"[[floing, current level],[Sensor]]\""
+										},
+										{
+											"key": "fuzzy",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Complex Text Geo",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Check response header\", function () {\r",
+											"    pm.response.to.have.header(\"Content-Type\",\"application/json\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Check response body\", function () {    \r",
+											"    const body = pm.response.json();\r",
+											"    pm.expect(body).to.have.property(\"type\", \"urn:dx:cat:Success\");\r",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{host}}{{base}}/search?q=\"flod senors\"&geoproperty=location&georel=within&geometry=Polygon&coordinates=[[[73.696,18.592],[73.69079,18.391],[73.96,18.3643],[74.09,18.526],[73.8947,18.689830],[73.696,18.592]]]&fuzzy=true",
+									"host": [
+										"{{host}}{{base}}"
+									],
+									"path": [
+										"search"
+									],
+									"query": [
+										{
+											"key": "q",
+											"value": "\"flod senors\""
+										},
+										{
+											"key": "geoproperty",
+											"value": "location"
+										},
+										{
+											"key": "georel",
+											"value": "within"
+										},
+										{
+											"key": "geometry",
+											"value": "Polygon"
+										},
+										{
+											"key": "coordinates",
+											"value": "[[[73.696,18.592],[73.69079,18.391],[73.96,18.3643],[74.09,18.526],[73.8947,18.689830],[73.696,18.592]]]"
+										},
+										{
+											"key": "filter",
+											"value": "[id, description]",
+											"disabled": true
+										},
+										{
+											"key": "fuzzy",
+											"value": "true"
 										}
 									]
 								}


### PR DESCRIPTION
Added Fuzzy Search in 5.6.0 branch. This will enable fuzzy search on attribute and text search queries. 
Fuzzy allows matching results with minor misspellings or variations in input terms.
The search is applied to tag, description and label.