### PR TITLE
Fix: schema of ai sandbox items

### DIFF
--- a/src/main/java/iudx/catalogue/server/validator/Constants.java
+++ b/src/main/java/iudx/catalogue/server/validator/Constants.java
@@ -10,6 +10,7 @@ public class Constants {
 
   public static final String ITEM_STATUS = "itemStatus";
   public static final String ACTIVE = "ACTIVE";
+  public static final String ITEM_CREATED_AT = "itemCreatedAt";
   public static final String LAST_UPDATED = "lastUpdated";
   public static final String CONTEXT = "@context";
 

--- a/src/main/java/iudx/catalogue/server/validator/ValidatorServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/validator/ValidatorServiceImpl.java
@@ -123,6 +123,12 @@ public class ValidatorServiceImpl implements ValidatorService {
    * Generates timestamp with timezone +05:30.
    */
   public static String getUtcDatetimeAsString() {
+    DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ssZ");
+    df.setTimeZone(TimeZone.getTimeZone("IST"));
+    return df.format(new Date());
+  }
+
+  public static String getPrettyLastUpdatedForUI() {
     DateTimeFormatter inputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ");
     DateTimeFormatter outputFormatter = DateTimeFormatter
         .ofPattern("dd MMMM, yyyy - hh:mm a", Locale.ENGLISH);
@@ -278,7 +284,8 @@ public class ValidatorServiceImpl implements ValidatorService {
       UUID uuid = UUID.randomUUID();
       request.put(ID, uuid.toString());
     }
-    request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getUtcDatetimeAsString());
+    request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getPrettyLastUpdatedForUI())
+        .put(ITEM_CREATED_AT, getUtcDatetimeAsString());
     String checkQuery = ITEM_WITH_NAME_EXISTS_QUERY
         .replace("$1", ITEM_TYPE_APPS).replace("$2", request.getString(NAME));
     LOGGER.debug(checkQuery);
@@ -308,8 +315,8 @@ public class ValidatorServiceImpl implements ValidatorService {
       request.put(ID, uuid.toString());
     }
 
-    request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getUtcDatetimeAsString());
-    String organization = request.getString(ORGANIZATION_ID);
+    request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getPrettyLastUpdatedForUI())
+        .put(ITEM_CREATED_AT, getUtcDatetimeAsString());
 
     String checkQuery = ITEM_WITH_NAME_EXISTS_QUERY
         .replace("$1", ITEM_TYPE_AI_MODEL).replace("$2", request.getString(NAME));
@@ -343,7 +350,8 @@ public class ValidatorServiceImpl implements ValidatorService {
       request.put(ID, uuid.toString());
     }
 
-    request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getUtcDatetimeAsString());
+    request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getPrettyLastUpdatedForUI())
+        .put(ITEM_CREATED_AT, getUtcDatetimeAsString());
 
     String checkQuery = ITEM_WITH_NAME_EXISTS_QUERY
         .replace("$1", ITEM_TYPE_DATA_BANK).replace("$2", request.getString(NAME));
@@ -377,7 +385,8 @@ public class ValidatorServiceImpl implements ValidatorService {
       request.put(ID, uuid.toString());
     }
 
-    request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getUtcDatetimeAsString());
+    request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getPrettyLastUpdatedForUI())
+        .put(ITEM_CREATED_AT, getUtcDatetimeAsString());
     String provider = request.getString(PROVIDER);
     String checkQuery =
         ITEM_EXISTS_QUERY
@@ -418,7 +427,8 @@ public class ValidatorServiceImpl implements ValidatorService {
       request.put(ID, uuid.toString());
     }
 
-    request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getUtcDatetimeAsString());
+    request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getPrettyLastUpdatedForUI())
+        .put(ITEM_CREATED_AT, getUtcDatetimeAsString());
     String resourceServer = request.getString(RESOURCE_SVR);
     String ownerUserId = request.getString(PROVIDER_USER_ID);
     String resourceServerUrl = request.getString(RESOURCE_SERVER_URL);
@@ -464,7 +474,8 @@ public class ValidatorServiceImpl implements ValidatorService {
       request.put(ID, uuid.toString());
     }
 
-    request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getUtcDatetimeAsString());
+    request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getPrettyLastUpdatedForUI())
+        .put(ITEM_CREATED_AT, getUtcDatetimeAsString());
     String cos = request.getString(COS_ITEM);
     String resourceServerUrl = request.getString(RESOURCE_SERVER_URL);
     String checkQuery =
@@ -511,7 +522,8 @@ public class ValidatorServiceImpl implements ValidatorService {
       request.put(ID, uuid.toString());
     }
 
-    request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getUtcDatetimeAsString());
+    request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getPrettyLastUpdatedForUI())
+        .put(ITEM_CREATED_AT, getUtcDatetimeAsString());
     String provider = request.getString(PROVIDER);
     String resourceGroup = request.getString(RESOURCE_GRP);
     String resourceServer = request.getString(RESOURCE_SVR);
@@ -568,7 +580,8 @@ public class ValidatorServiceImpl implements ValidatorService {
       UUID uuid = UUID.randomUUID();
       request.put(ID, uuid.toString());
     }
-    request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getUtcDatetimeAsString());
+    request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getPrettyLastUpdatedForUI())
+        .put(ITEM_CREATED_AT, getUtcDatetimeAsString());
 
     String owner = request.getString(OWNER);
     String checkQuery =
@@ -608,7 +621,8 @@ public class ValidatorServiceImpl implements ValidatorService {
       UUID uuid = UUID.randomUUID();
       request.put(ID, uuid.toString());
     }
-    request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getUtcDatetimeAsString());
+    request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getPrettyLastUpdatedForUI())
+        .put(ITEM_CREATED_AT, getUtcDatetimeAsString());
     String checkQuery = OWNER_ITEM_EXISTS_QUERY.replace("$1", request.getString(NAME));
     LOGGER.debug(checkQuery);
     client.searchGetId(

--- a/src/main/resources/iudx/catalogue/server/validator/adexAiModelItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/adexAiModelItemSchema.json
@@ -143,7 +143,7 @@
       "type": "string",
       "title": "The organizationType schema",
       "description": "Type of organization providing the model",
-      "enum": ["Private", "Public", "Academic Institution", "NGO/Non-profit"]
+      "enum": ["Private", "Public", "Academic Institution", "NGO/Non-profit", "Other"]
     },"organizationId": {
       "$id": "#/properties/organizationId",
       "type": "string",

--- a/src/main/resources/iudx/catalogue/server/validator/adexAppsItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/adexAppsItemSchema.json
@@ -146,7 +146,7 @@
       "type": "string",
       "title": "The organizationType schema",
       "description": "Type of organization providing the model",
-      "enum": ["Private", "Public", "Academic Institution", "NGO/Non-profit"]
+      "enum": ["Private", "Public", "Academic Institution", "NGO/Non-profit", "Other"]
     },
     "department": {
       "type": "string",

--- a/src/main/resources/iudx/catalogue/server/validator/adexDataBankResourceItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/adexDataBankResourceItemSchema.json
@@ -143,7 +143,7 @@
     "organizationType": {
       "type": "string",
       "title": "The organizationType schema",
-      "enum": ["Private", "Public", "Academic Institution", "NGO/Non-profit"]
+      "enum": ["Private", "Public", "Academic Institution", "NGO/Non-profit", "Other"]
     },
     "shortDescription": {
       "type": "string",

--- a/src/main/resources/iudx/catalogue/server/validator/temporalSearchQuerySchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/temporalSearchQuerySchema.json
@@ -6,7 +6,7 @@
   "properties": {
     "field": {
       "type": "string",
-      "enum": ["observationDateTime", "itemCreatedAt", "itemModifiedAt", "itemUpdatedAt"]
+      "enum": ["observationDateTime", "itemCreatedAt", "itemModifiedAt", "itemUpdatedAt", "lastUpdated"]
     },
     "searchType": {
       "enum": ["betweenTemporal", "beforeTemporal", "afterTemporal"]


### PR DESCRIPTION
- Added "Other" as a valid value to the organizationType enum.
- Fixed an oversight from the last commit where changes related to itemCreatedAt were not included. The UI uses both lastUpdated and itemCreatedAt, and itemCreatedAt is essential for the temporal APIs. This PR restores the addition of itemCreatedAt to ensure proper functionality.