### PR TITLE
Allow blank value in organizationType field in schema validation to handle NA data

### DIFF
--- a/src/main/resources/iudx/catalogue/server/validator/adexAiModelItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/adexAiModelItemSchema.json
@@ -143,7 +143,7 @@
       "type": "string",
       "title": "The organizationType schema",
       "description": "Type of organization providing the model",
-      "enum": ["Private", "Public", "Academic Institution", "NGO/Non-profit", "Other"]
+      "enum": ["Private", "Public", "Academic Institution", "NGO/Non-profit", "Other", "NA", ""]
     },"organizationId": {
       "$id": "#/properties/organizationId",
       "type": "string",

--- a/src/main/resources/iudx/catalogue/server/validator/adexAppsItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/adexAppsItemSchema.json
@@ -146,7 +146,7 @@
       "type": "string",
       "title": "The organizationType schema",
       "description": "Type of organization providing the model",
-      "enum": ["Private", "Public", "Academic Institution", "NGO/Non-profit", "Other"]
+      "enum": ["Private", "Public", "Academic Institution", "NGO/Non-profit", "Other", "NA", ""]
     },
     "department": {
       "type": "string",

--- a/src/main/resources/iudx/catalogue/server/validator/adexDataBankResourceItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/adexDataBankResourceItemSchema.json
@@ -143,7 +143,7 @@
     "organizationType": {
       "type": "string",
       "title": "The organizationType schema",
-      "enum": ["Private", "Public", "Academic Institution", "NGO/Non-profit", "Other"]
+      "enum": ["Private", "Public", "Academic Institution", "NGO/Non-profit", "Other", "NA", ""]
     },
     "shortDescription": {
       "type": "string",

--- a/src/main/resources/iudx/catalogue/server/validator/attributeSearchQuerySchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/attributeSearchQuerySchema.json
@@ -9,7 +9,7 @@
     "values": {
       "type": "array",
       "minItems": 1,
-      "maxItems": 10,
+      "maxItems": 20,
       "items": {
         "type": "string",
         "pattern": "^[a-zA-Z0-9]([\\w\\-.,:/()& ]*[a-zA-Z0-9])?$"


### PR DESCRIPTION
The organizationType field currently restricts values to the enum:
["Private", "Public", "Academic Institution", "NGO/Non-profit", "Other"].

Production data contains NA values for this field, which causes schema validation failures. As per clarification, NA values should be treated as blank/empty strings in the UI and allowed by the schema.

This PR updates the schema validation to accept either one of the allowed enum values or a blank string ("") for organizationType.