### PR TITLE
Remove mediaURL from required fields and allow spaces in name field

### DIFF
--- a/src/main/java/iudx/catalogue/server/apiserver/CrudApis.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/CrudApis.java
@@ -147,8 +147,6 @@ public final class CrudApis {
 
             JsonObject jwtAuthenticationInfo = new JsonObject();
 
-            HttpServerRequest request = routingContext.request();
-
             // populating jwt authentication info ->
             jwtAuthenticationInfo
                 .put(TOKEN, routingContext.get(HEADER_TOKEN))
@@ -465,7 +463,6 @@ public final class CrudApis {
     //    if (validateId(itemId) == true) {
 
     //  populating JWT authentication info ->
-    HttpServerRequest request = routingContext.request();
     jwtAuthenticationInfo
         .put(TOKEN, routingContext.get(HEADER_TOKEN))
         .put(METHOD, REQUEST_DELETE)
@@ -638,7 +635,6 @@ public final class CrudApis {
     LOGGER.debug("Info: Creating new instance");
 
     HttpServerResponse response = routingContext.response();
-    HttpServerRequest request = routingContext.request();
     response.putHeader(HEADER_CONTENT_TYPE, MIME_APPLICATION_JSON);
 
 
@@ -703,7 +699,6 @@ public final class CrudApis {
     LOGGER.debug("Info: Deleting instance");
 
     HttpServerResponse response = routingContext.response();
-    HttpServerRequest request = routingContext.request();
     response.putHeader(HEADER_CONTENT_TYPE, MIME_APPLICATION_JSON);
 
     JsonObject authenticationInfo = new JsonObject();

--- a/src/main/resources/iudx/catalogue/server/validator/adexAiModelItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/adexAiModelItemSchema.json
@@ -59,7 +59,7 @@
       "default": "",
       "examples": ["SomePlace"],
       "maxLength": 512,
-      "pattern": "^[a-zA-Z0-9]([\\w-]*[a-zA-Z0-9 ])?$"
+      "pattern": "^[a-zA-Z0-9]([\\w- ]*[a-zA-Z0-9 ])?$"
     },
     "id": {
       "$id": "#/properties/id",

--- a/src/main/resources/iudx/catalogue/server/validator/adexAppsItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/adexAppsItemSchema.json
@@ -74,7 +74,7 @@
       "default": "",
       "examples": ["SomePlace"],
       "maxLength": 512,
-      "pattern": "^[a-zA-Z0-9]([\\w-]*[a-zA-Z0-9 ])?$"
+      "pattern": "^[a-zA-Z0-9]([\\w- ]*[a-zA-Z0-9 ])?$"
     },
     "id": {
       "$id": "#/properties/id",

--- a/src/main/resources/iudx/catalogue/server/validator/adexDataBankResourceItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/adexDataBankResourceItemSchema.json
@@ -45,7 +45,6 @@
     "geoCoverage",
     "yearRange",
     "verifiedBy",
-    "mediaURL",
     "uploadFrequency",
     "license"
   ],
@@ -58,7 +57,7 @@
       "default": "",
       "examples": ["SomePlace"],
       "maxLength": 512,
-      "pattern": "^[a-zA-Z0-9]([\\w-]*[a-zA-Z0-9 ])?$"
+      "pattern": "^[a-zA-Z0-9]([\\w- ]*[a-zA-Z0-9 ])?$"
     },
     "id": {
       "$id": "#/properties/id",


### PR DESCRIPTION
This PR includes the following schema updates for the **Data Bank** entity:

1. **Removed `mediaURL` from required fields**
   - `mediaURL` was listed as required but is not present in the data sheet.
   - Updated the schema to make `mediaURL` optional.

2. **Updated regex pattern for `name` field**
   - Modified the regex to allow spaces within the `name` value.
   - Enables names like `"Traffic Dashboard Telangana"` to pass validation.
