### PR TITLE
Add pagination block to /search API response

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -27,20 +27,43 @@ info:
       - The `<payload>` in the request sample could be replaced with the payload given adjacent to the request sample
       - The payload contains `<some_item_id>`, `<provider_id>`, `<some_item_name>`, for which the appropriate values could be added 
     
-    # Pagination
-    Catalogue server also offers way to paginate the result for queries. If a query returns large number of records then user can use additional parameters in query parameters to limit numbers of records to be returned.
-    
-    - <b> Pagination is applicable only for</b>
-       - <b>/search</b>
-    
-    Additional query parameters to be used:
-      - <b>offset</b> : The from parameter defines the offset from the first result you want to fetch,  ( <i>default : 0</i> ,<i>minValue: 0</i>, <i>maxValue: 10000</i> )
-      - <b>limit</b> : The size parameter allows you to configure the maximum results to be returned  ( <i>default: 10000</i> ,<i>minValue: 0</i>, <i>maxValue: 10000</i> )
-
      # API HTTP Responses
     Apart from the response codes specified in each API,
     the API server may respond with certain 4xx and 5xx error codes which are related to common API Gateway behaviours.
     The application should address them accordingly.
+    
+    # Pagination
+    The Catalogue server supports paginating query results to help users manage large datasets efficiently. If a query returns a large number of records, pagination parameters can be used to control how many results are returned per page and which page to fetch.
+    
+    - **Pagination is applicable only for:**
+      - **/search**
+
+    📥 **Query Parameters for Pagination**:
+    - **page**: Specifies which page of the result set to retrieve.  
+      *(Default: 1, Min: 1)*
+
+    - **size**: Specifies how many results should be returned per page.  
+      *(Default: 100, Min: 1, Max: 10000)*
+
+  parameters:
+    - name: page
+      in: query
+      description: Specifies which page of the result set to retrieve
+      required: false
+      schema:
+        type: integer
+        default: 1
+        minimum: 1
+
+    - name: size
+      in: query
+      description: Specifies how many results should be returned per page.
+      required: false
+      schema:
+        type: integer
+        default: 100
+        minimum: 1
+        maximum: 10000
   contact:
     name: For support contact IUDX Team at
     email: support@cdpg.org.in
@@ -183,11 +206,13 @@ paths:
         ```
 
         #### Limits and Filters
-        - Results can be paginated using `limit` and `offset`.  
-          For example, `limit=100&offset=10` returns 100 results starting from the 11th.
-        - A subset of properties can be returned using the `filter` parameter.  
-          For example, `filter=[id]` returns only the `id` field for each document.
-        - The sum of `offset` and `limit` must be `<= 10000`.
+        - Pagination: Use `size` and `page` parameters to paginate results.  
+          For example, `size=100&page=2` returns 100 results starting from the 101st record (i.e., page 2).  
+          Internally, the offset is calculated as `offset = size * (page - 1)`.
+        - Field Filtering: Use the `filter` parameter to specify a subset of fields to return.  
+          For example, `filter=[id]` returns only the `id` field for each result.
+        - Limits: The sum of the internally calculated `offset` and `size` must be less than or equal to `10,000` to prevent overly large queries.
+
       operationId: search
       parameters:
         - name: instance
@@ -280,37 +305,33 @@ paths:
         - lang: cURL
           label: search by item type
           source: |
-            curl --location --request POST 'https://example-cat.com/iudx/cat/v1/search' \
-            --header 'Content-Type: application/json' \
-            --data '{
-              "searchCriteria": [
-                {
-                  "searchType": "term",
-                  "field": "type",
-                  "values": ["adex:AiModel"]
-                }
-              ],
-              "filter": ["id"],
-              "limit": 100,
-              "offset": 0
-            }'
+            curl --location --request POST 'https://example-cat.com/iudx/cat/v1/search?size=100&page=1' \
+              --header 'Content-Type: application/json' \
+              --data '{
+                "searchCriteria": [
+                  {
+                    "searchType": "term",
+                    "field": "type",
+                    "values": ["adex:AiModel"]
+                  }
+                ],
+                "filter": ["id"]
+              }'
         - lang: cURL
           label: search by text
           source: |
-            curl --location --request POST 'https://example-cat.com/iudx/cat/v1/search' \
+            curl --location --request POST 'https://example-cat.com/iudx/cat/v1/search?size=100&page=1' \
             --header 'Content-Type: application/json' \
             --data '{
               "q": "sat",
               "autoComplete": true,
               "fuzzy": true,
-              "filter": ["id", "label", "name", "description", "tags"],
-              "limit": 100,
-              "offset": 0
+              "filter": ["id", "label", "name", "description", "tags"]
             }'
         - lang: cURL
           label: Temporal search
           source: |
-            curl --location --request POST 'https://example-cat.com/iudx/cat/v1/search' \
+            curl --location --request POST 'https://example-cat.com/iudx/cat/v1/search?size=50&page=1' \
             --header 'Content-Type: application/json' \
             --data '{
               "searchCriteria": [
@@ -325,14 +346,12 @@ paths:
                   "values": ["adex:AiModel"]
                 }
               ],
-              "filter": ["id","tags","itemCreatedAt"],
-              "limit": 50,
-              "offset": 0
+              "filter": ["id","tags","itemCreatedAt"]
             }'
         - lang: cURL
           label: Range search
           source: |
-            curl --location --request POST 'https://example-cat.com/iudx/cat/v1/search' \
+            curl --location --request POST 'https://example-cat.com/iudx/cat/v1/search?size=25&page=1' \
             --header 'Content-Type: application/json' \
             --data '{
               "searchCriteria": [
@@ -347,39 +366,37 @@ paths:
                   "values": ["adex:DataBank"]
                 }
               ],
-              "filter": ["id","dataReadiness","tags"],
-              "limit": 25,
-              "offset": 0
+              "filter": ["id","dataReadiness","tags"]
             }'
         - lang: cURL
           label: complex search
           source: |
-            curl --location --request POST 'https://example-cat.com/iudx/cat/v1/search' \
+            curl --location --request POST 'https://example-cat.com/iudx/cat/v1/search?size=25&page=1' \
             --header 'Content-Type: application/json' \
             --data '{
-            "searchCriteria": [
-              {
-                "searchType": "term",
-                "field": "type",
-                "values": ["adex:DataBank"]
-              },
-              {
-                "searchType": "term",
-                "field": "department",
-                "values": ["Environment Forests Science and Technology"]
-              },
-              {
-                "searchType": "betweenTemporal",
-                "field": "itemCreatedAt",
-                "values": ["2024-04-20T04:00:00+0530", "2025-05-02T09:15:27+0530"]
-              },
-              {
-                "searchType": "betweenRange",
-                "field": "dataReadiness",
-                "values": [80, 84]
-              }
-            ],
-            "filter": ["id", "type", "department", "itemCreatedAt", "dataReadiness"]
+              "searchCriteria": [
+                {
+                  "searchType": "term",
+                  "field": "type",
+                  "values": ["adex:DataBank"]
+                },
+                {
+                  "searchType": "term",
+                  "field": "department",
+                  "values": ["Environment Forests Science and Technology"]
+                },
+                {
+                  "searchType": "betweenTemporal",
+                  "field": "itemCreatedAt",
+                  "values": ["2024-04-20T04:00:00+0530", "2025-05-02T09:15:27+0530"]
+                },
+                {
+                  "searchType": "betweenRange",
+                  "field": "dataReadiness",
+                  "values": [80, 84]
+                }
+              ],
+              "filter": ["id", "type", "department", "itemCreatedAt", "dataReadiness"]
             }'
   '/list':
     post:
@@ -1005,14 +1022,6 @@ components:
           items:
             type: string
           description: List of properties to include in the response (e.g., id, label, name, description, tags).
-        limit:
-          type: integer
-          description: Limit the number of records returned in the response.
-          minimum: 1
-        offset:
-          type: integer
-          description: Offset from where the next batch of results should be returned.
-          minimum: 0
       required:
         - q
       example:
@@ -1025,8 +1034,6 @@ components:
           - "name"
           - "description"
           - "tags"
-        limit: 100
-        offset: 0
     SearchCriteriaRequest:
       type: object
       properties:
@@ -1035,14 +1042,6 @@ components:
           items:
             $ref: '#/components/schemas/SearchCriteria'
           description: List of property-based search criteria.
-          limit:
-            type: integer
-            description: Limit number of records in search response.
-            minimum: 1
-          offset:
-            type: integer
-            description: Offset from where the next batch of results should be returned.
-            minimum: 0
           filter:
             in: query
             description: Filter properties to display. This is an array of strings.
@@ -1065,14 +1064,6 @@ components:
         autoComplete:
           type: boolean
           description: Enables autocomplete suggestions.
-        limit:
-          type: integer
-          description: Limit number of records in search response.
-          minimum: 1
-        offset:
-          type: integer
-          description: Offset from where the next batch of results should be returned.
-          minimum: 0
         filter:
           in: query
           description: Filter properties to display. This is an array of strings.
@@ -1100,14 +1091,6 @@ components:
           items:
             $ref: '#/components/schemas/SearchCriteria'
           description: List of property-based search criteria.
-        limit:
-          type: integer
-          description: Limit number of records in search response.
-          minimum: 1
-        offset:
-          type: integer
-          description: Offset from where the next batch of results should be returned.
-          minimum: 0
         filter:
           in: query
           description: Filter properties to display. This is an array of strings.
@@ -2609,9 +2592,34 @@ components:
         title:
           type: string
           description: A human-readable title for the message response.
-        totalHits:
-          type: integer
-          description: The total number of hits for the search.
+        pagination:
+          type: object
+          properties:
+            page:
+              type: integer
+              description: Current page number.
+            size:
+              type: integer
+              description: Number of items per page.
+            totalCount:
+              type: integer
+              description: Total number of items across all pages.
+            totalPages:
+              type: integer
+              description: Total number of pages.
+            hasNext:
+              type: boolean
+              description: Whether there is a next page.
+            hasPrevious:
+              type: boolean
+              description: Whether there is a previous page.
+          required:
+            - page
+            - size
+            - totalCount
+            - totalPages
+            - hasNext
+            - hasPrevious
         results:
           type: array
           items:
@@ -2643,12 +2651,18 @@ components:
       required:
         - type
         - title
-        - totalHits
+        - pagination
         - results
       example:
         type: "urn:dx:cat:Success"
         title: "Success"
-        totalHits: 5
+        pagination:
+          page: 1
+          size: 100
+          totalCount: 5
+          totalPages: 1
+          hasNext: false
+          hasPrevious: false
         results:
           - id: "32cf54e7-be31-474c-ae4c-3d41e556dd2d"
             label: "Satellite-Derived Geospatial Layers"
@@ -2721,9 +2735,35 @@ components:
         title:
           type: string
           description: A human-readable title for the message response
-        totalHits:
-          type: integer
-          description: The total number of hits for the search
+        pagination:
+          type: object
+          description: Pagination metadata for the results
+          properties:
+            page:
+              type: integer
+              description: Current page number
+            size:
+              type: integer
+              description: Number of items per page
+            totalCount:
+              type: integer
+              description: Total number of items across all pages
+            totalPages:
+              type: integer
+              description: Total number of pages available
+            hasNext:
+              type: boolean
+              description: Indicates if more pages are available
+            hasPrevious:
+              type: boolean
+              description: Indicates if previous pages exist
+          required:
+            - page
+            - size
+            - totalCount
+            - totalPages
+            - hasNext
+            - hasPrevious
         results:
           type: array
           items:
@@ -2731,7 +2771,8 @@ components:
             properties:
               type:
                 type: array
-                items: string
+                items:
+                  type: string
                 description: List of resource types
               id:
                 type: string
@@ -2751,18 +2792,92 @@ components:
       required:
         - type
         - title
-        - totalHits
+        - pagination
         - results
       example:
         type: "urn:dx:cat:Success"
         title: "Success"
-        totalHits: 1
+        pagination:
+          page: 1
+          size: 25
+          totalCount: 1
+          totalPages: 1
+          hasNext: false
+          hasPrevious: false
         results:
           - type:
               - "adex:DataBank"
             id: "32cf54e7-be31-474c-ae4c-3d41e556dd2d"
             department: "Environment Forests Science and Technology"
             itemCreatedAt: "2025-04-15T10:30:00Z"
+    successResponseForSearchByItemType:
+      type: object
+      title: search by item type
+      properties:
+        type:
+          type: string
+          description: URN type of the response indicating if the query was successful or if any errors have been triggered.
+        title:
+          type: string
+          description: A human-readable title for the message response.
+        pagination:
+          type: object
+          description: Pagination metadata for the results.
+          properties:
+            page:
+              type: integer
+              description: Current page number.
+            size:
+              type: integer
+              description: Number of items per page.
+            totalCount:
+              type: integer
+              description: Total number of items across all pages.
+            totalPages:
+              type: integer
+              description: Total number of pages available.
+            hasNext:
+              type: boolean
+              description: Indicates if more pages are available.
+            hasPrevious:
+              type: boolean
+              description: Indicates if previous pages exist.
+          required:
+            - page
+            - size
+            - totalCount
+            - totalPages
+            - hasNext
+            - hasPrevious
+        results:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Resource identifier.
+            required:
+              - id
+      required:
+        - type
+        - title
+        - pagination
+        - results
+      example:
+        type: "urn:dx:cat:Success"
+        title: "Success"
+        pagination:
+          page: 1
+          size: 100
+          totalCount: 3
+          totalPages: 1
+          hasNext: false
+          hasPrevious: false
+        results:
+          - id: "a4e3b98f-d073-4a2f-8587-e8d1718f2a89"
+          - id: "d7d34f8d-8cd4-4a68-8a4d-3b7fc5e8bb13"
+          - id: "2b1a2e8d-45f4-43a1-9e8e-d1f8ad1002bb"
     successResponseForRangeSearch:
       type: object
       title: Range search
@@ -2773,9 +2888,35 @@ components:
         title:
           type: string
           description: A human-readable title for the message response
-        totalHits:
-          type: integer
-          description: The total number of hits for the search
+        pagination:
+          type: object
+          description: Pagination metadata for the results
+          properties:
+            page:
+              type: integer
+              description: Current page number
+            size:
+              type: integer
+              description: Number of items per page
+            totalCount:
+              type: integer
+              description: Total number of items across all pages
+            totalPages:
+              type: integer
+              description: Total number of pages available
+            hasNext:
+              type: boolean
+              description: Indicates if more pages are available
+            hasPrevious:
+              type: boolean
+              description: Indicates if previous pages exist
+          required:
+            - page
+            - size
+            - totalCount
+            - totalPages
+            - hasNext
+            - hasPrevious
         results:
           type: array
           items:
@@ -2786,20 +2927,30 @@ components:
                 description: Resource identifier
               tags:
                 type: array
-                items: string
+                items:
+                  type: string
                 description: List of tags associated with the resource
+              dataReadiness:
+                type: integer
+                description: Optional field indicating how ready the data is (if applicable)
             required:
               - id
               - tags
       required:
         - type
         - title
-        - totalHits
+        - pagination
         - results
       example:
         type: "urn:dx:cat:Success"
         title: "Success"
-        totalHits: 5
+        pagination:
+          page: 1
+          size: 25
+          totalCount: 5
+          totalPages: 1
+          hasNext: false
+          hasPrevious: false
         results:
           - id: "32cf54e7-be31-474c-ae4c-3d41e556dd2d"
             tags:
@@ -2834,9 +2985,35 @@ components:
         title:
           type: string
           description: A human-readable title for the message response
-        totalHits:
-          type: integer
-          description: The total number of hits for the search
+        pagination:
+          type: object
+          description: Pagination metadata for the results.
+          properties:
+            page:
+              type: integer
+              description: Current page number.
+            size:
+              type: integer
+              description: Number of items per page.
+            totalCount:
+              type: integer
+              description: Total number of items across all pages.
+            totalPages:
+              type: integer
+              description: Total number of pages available.
+            hasNext:
+              type: boolean
+              description: Indicates if more pages are available.
+            hasPrevious:
+              type: boolean
+              description: Indicates if previous pages exist.
+          required:
+            - page
+            - size
+            - totalCount
+            - totalPages
+            - hasNext
+            - hasPrevious
         results:
           type: array
           items:
@@ -2847,7 +3024,8 @@ components:
                 description: Resource identifier
               tags:
                 type: array
-                items: string
+                items:
+                  type: string
                 description: List of tags associated with the resource
               itemCreatedAt:
                 type: string
@@ -2860,12 +3038,18 @@ components:
       required:
         - type
         - title
-        - totalHits
+        - pagination
         - results
       example:
         type: "urn:dx:cat:Success"
         title: "Success"
-        totalHits: 3
+        pagination:
+          page: 1
+          size: 50
+          totalCount: 3
+          totalPages: 1
+          hasNext: false
+          hasPrevious: false
         results:
           - id: "a4e3b98f-d073-4a2f-8587-e8d1718f2a89"
             tags:
@@ -2900,42 +3084,6 @@ components:
               - "risk prediction"
               - "student analytics"
             itemCreatedAt: "2025-04-15T10:30:00Z"
-    successResponseForSearchByItemType:
-      type: object
-      title: search by item type
-      properties:
-        type:
-          type: string
-          description: URN type of the response indicating if the query was successful or if any errors have been triggered.
-        title:
-          type: string
-          description: A human-readable title for the message response.
-        totalHits:
-          type: integer
-          description: The total number of hits for the search.
-        results:
-          type: array
-          items:
-            type: object
-            properties:
-              id:
-                type: string
-                description: Resource identifier.
-            required:
-              - id
-      required:
-        - type
-        - title
-        - totalHits
-        - results
-      example:
-        type: "urn:dx:cat:Success"
-        title: "Success"
-        totalHits: 3
-        results:
-          - id: "a4e3b98f-d073-4a2f-8587-e8d1718f2a89"
-          - id: "d7d34f8d-8cd4-4a68-8a4d-3b7fc5e8bb13"
-          - id: "2b1a2e8d-45f4-43a1-9e8e-d1f8ad1002bb"
     errorInvalidSchema:
       type: object
       title: Response - invalid schema

--- a/src/main/java/iudx/catalogue/server/apiserver/SearchApis.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/SearchApis.java
@@ -8,6 +8,8 @@ package iudx.catalogue.server.apiserver;
 import static iudx.catalogue.server.apiserver.util.Constants.*;
 import static iudx.catalogue.server.authenticator.Constants.API_ENDPOINT;
 import static iudx.catalogue.server.authenticator.Constants.TOKEN;
+import static iudx.catalogue.server.database.Constants.PAGE_KEY;
+import static iudx.catalogue.server.database.Constants.SIZE_KEY;
 import static iudx.catalogue.server.util.Constants.*;
 
 import io.vertx.core.MultiMap;
@@ -231,6 +233,34 @@ public final class SearchApis {
     /* HTTP request instance/host details */
     String instanceId = request.getHeader(HEADER_INSTANCE);
     requestBody.put(HEADER_INSTANCE, instanceId);
+
+    // Set default size and page
+    int size = DEFAULT_MAX_PAGE_SIZE;
+    int page = DEFAULT_PAGE_NUMBER;
+
+    // Override if query params are present
+    if (request.getParam(SIZE_KEY) != null) {
+      try {
+        size = Integer.parseInt(request.getParam(SIZE_KEY));
+      } catch (NumberFormatException e) {
+        LOGGER.warn("Invalid size param, defaulting to 100");
+      }
+    }
+
+    if (request.getParam(PAGE_KEY) != null) {
+      try {
+        page = Integer.parseInt(request.getParam(PAGE_KEY));
+      } catch (NumberFormatException e) {
+        LOGGER.warn("Invalid page param, defaulting to 1");
+      }
+    }
+
+    int offset = size * (page - 1);
+
+    requestBody.put(SIZE_KEY, size);
+    requestBody.put(LIMIT, size);
+    requestBody.put(PAGE_KEY, page);
+    requestBody.put(OFFSET, offset);
 
     if (token != null && !token.isEmpty()) {
       JsonObject jwtAuthenticationInfo = new JsonObject()

--- a/src/main/java/iudx/catalogue/server/apiserver/SearchApis.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/SearchApis.java
@@ -228,7 +228,6 @@ public final class SearchApis {
     response.putHeader(HEADER_CONTENT_TYPE, MIME_APPLICATION_JSON);
 
     JsonObject requestBody = routingContext.body().asJsonObject();
-    String token = routingContext.get(HEADER_TOKEN);
 
     /* HTTP request instance/host details */
     String instanceId = request.getHeader(HEADER_INSTANCE);
@@ -262,6 +261,7 @@ public final class SearchApis {
     requestBody.put(PAGE_KEY, page);
     requestBody.put(OFFSET, offset);
 
+    String token = routingContext.get(HEADER_TOKEN);
     if (token != null && !token.isEmpty()) {
       JsonObject jwtAuthenticationInfo = new JsonObject()
           .put(TOKEN, token)

--- a/src/main/java/iudx/catalogue/server/auditing/util/AuditMetadata.java
+++ b/src/main/java/iudx/catalogue/server/auditing/util/AuditMetadata.java
@@ -21,8 +21,9 @@ public class AuditMetadata {
   public final String userRole;
   public final String shortDescription;
 
-  public AuditMetadata(String itemId, String shortDescription, String apiEndpoint, String httpMethod,
-                       String itemType, String itemName, String userId, String userRole) {
+  public AuditMetadata(String itemId, String shortDescription, String apiEndpoint,
+                       String httpMethod, String itemType, String itemName, String userId,
+                       String userRole) {
     this.itemId = itemId;
     this.apiEndpoint = apiEndpoint;
     this.httpMethod = httpMethod;

--- a/src/main/java/iudx/catalogue/server/database/Constants.java
+++ b/src/main/java/iudx/catalogue/server/database/Constants.java
@@ -308,6 +308,12 @@ public class Constants {
   static final String RESULT = "results";
   static final String SHAPE_KEY = "shape";
   static final String SIZE_KEY = "size";
+  static final String PAGE_KEY = "page";
+  public static final String TOTAL_COUNT = "totalCount";
+  public static final String TOTAL_PAGES = "totalPages";
+  public static final String HAS_NEXT = "hasNext";
+  public static final String HAS_PREVIOUS = "hasPrevious";
+  public static final String PAGINATION = "pagination";
   static final int STATIC_DELAY_TIME = 3000;
   /* Database */
   static final String AGGREGATION_KEY = "aggs";

--- a/src/main/java/iudx/catalogue/server/database/Constants.java
+++ b/src/main/java/iudx/catalogue/server/database/Constants.java
@@ -307,8 +307,8 @@ public class Constants {
   static final String ATTRIBUTE = "attrs";
   static final String RESULT = "results";
   static final String SHAPE_KEY = "shape";
-  static final String SIZE_KEY = "size";
-  static final String PAGE_KEY = "page";
+  public static final String SIZE_KEY = "size";
+  public static final String PAGE_KEY = "page";
   public static final String TOTAL_COUNT = "totalCount";
   public static final String TOTAL_PAGES = "totalPages";
   public static final String HAS_NEXT = "hasNext";

--- a/src/main/java/iudx/catalogue/server/database/DatabaseServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/database/DatabaseServiceImpl.java
@@ -194,7 +194,7 @@ public class DatabaseServiceImpl implements DatabaseService {
             int totalPages = (int) Math.ceil((double) totalHits / size);
             int page = request.getInteger(PAGE_KEY, 1);
             boolean hasNext = totalHits > 0 && page < totalPages;
-            boolean hasPrevious = (page > 1) && (page <= totalPages);
+            boolean hasPrevious = page > 1 && page <= totalPages;
 
             JsonObject pagination = new JsonObject()
                 .put(PAGE_KEY, page)

--- a/src/main/java/iudx/catalogue/server/database/DatabaseServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/database/DatabaseServiceImpl.java
@@ -189,12 +189,12 @@ public class DatabaseServiceImpl implements DatabaseService {
           if (searchRes.succeeded()) {
             LOGGER.debug("Success: Successful DB request");
             int totalHits = searchRes.result().getInteger(TOTAL_HITS);
-            int offset = request.getInteger(OFFSET, 1);
-            int size = request.getInteger(LIMIT, DEFAULT_MAX_PAGE_SIZE);
-            int page = (int) (floor((double) offset / size) + 1);
+            int size = request.getInteger(SIZE_KEY, DEFAULT_MAX_PAGE_SIZE);
+
             int totalPages = (int) Math.ceil((double) totalHits / size);
-            boolean hasNext = page < totalPages;
-            boolean hasPrevious = page > 1;
+            int page = request.getInteger(PAGE_KEY, 1);
+            boolean hasNext = totalHits > 0 && page < totalPages;
+            boolean hasPrevious = (page > 1) && (page <= totalPages);
 
             JsonObject pagination = new JsonObject()
                 .put(PAGE_KEY, page)
@@ -203,7 +203,9 @@ public class DatabaseServiceImpl implements DatabaseService {
                 .put(TOTAL_PAGES, totalPages)
                 .put(HAS_NEXT, hasNext)
                 .put(HAS_PREVIOUS, hasPrevious);
+
             searchRes.result().put(PAGINATION, pagination);
+            searchRes.result().remove(TOTAL_HITS);
             handler.handle(Future.succeededFuture(searchRes.result()));
           } else {
             LOGGER.error("Fail: DB Request;" + searchRes.cause().getMessage());

--- a/src/main/java/iudx/catalogue/server/database/QueryDecoder.java
+++ b/src/main/java/iudx/catalogue/server/database/QueryDecoder.java
@@ -76,7 +76,7 @@ public final class QueryDecoder {
     /* TODO: Pagination for large result set */
     if (request.getBoolean(SEARCH)) {
       Integer limit =
-          request.getInteger(LIMIT, FILTER_PAGINATION_SIZE - request.getInteger(OFFSET, 0));
+          request.getInteger(LIMIT, DEFAULT_MAX_PAGE_SIZE - request.getInteger(OFFSET, 0));
       elasticQuery.put(SIZE_KEY, limit);
     }
 

--- a/src/main/java/iudx/catalogue/server/util/Constants.java
+++ b/src/main/java/iudx/catalogue/server/util/Constants.java
@@ -221,7 +221,8 @@ public class Constants {
   public static final int FILTER_PAGINATION_SIZE = 10000;
   public static final int OFFSET_PAGINATION_SIZE = 9999;
   public static final int MAX_RESULT_WINDOW = 10000;
-  public static final int DEFAULT_MAX_PAGE_SIZE= 10;
+  public static final int DEFAULT_MAX_PAGE_SIZE= 100;
+  public static final int DEFAULT_PAGE_NUMBER= 1;
   public static final int MAXDISTANCE_LIMIT = 10000; // 10KM
   public static final int SERVICE_TIMEOUT = 3000;
   public static final int POPULAR_DATASET_COUNT = 6;

--- a/src/main/java/iudx/catalogue/server/util/Constants.java
+++ b/src/main/java/iudx/catalogue/server/util/Constants.java
@@ -221,8 +221,8 @@ public class Constants {
   public static final int FILTER_PAGINATION_SIZE = 10000;
   public static final int OFFSET_PAGINATION_SIZE = 9999;
   public static final int MAX_RESULT_WINDOW = 10000;
-  public static final int DEFAULT_MAX_PAGE_SIZE= 100;
-  public static final int DEFAULT_PAGE_NUMBER= 1;
+  public static final int DEFAULT_MAX_PAGE_SIZE = 100;
+  public static final int DEFAULT_PAGE_NUMBER = 1;
   public static final int MAXDISTANCE_LIMIT = 10000; // 10KM
   public static final int SERVICE_TIMEOUT = 3000;
   public static final int POPULAR_DATASET_COUNT = 6;

--- a/src/test/resources/AI Sandbox - CAT.postman_collection.json
+++ b/src/test/resources/AI Sandbox - CAT.postman_collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
 		"_postman_id": "43215f38-7ce9-4af7-ad83-4796416f8f2c",
-		"name": "AI Sandbox | CAT | Latest collection",
+		"name": "AI Sandbox | CAT | Postman collection",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "29449699",
 		"_collection_link": "https://kranthi-7706.postman.co/workspace/AI-SandBox-Workspace~7b17c3e8-8468-4272-ac8a-42e14886620a/collection/29449699-43215f38-7ce9-4af7-ad83-4796416f8f2c?action=share&source=collection_link&creator=29449699"
@@ -1251,9 +1251,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{localhost}}{{base}}/item?id={{adex_apps_id}}",
+									"raw": "{{host}}{{base}}/item?id={{adex_apps_id}}",
 									"host": [
-										"{{localhost}}{{base}}"
+										"{{host}}{{base}}"
 									],
 									"path": [
 										"item"
@@ -1974,7 +1974,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"q\" : \"Bosch Climo\",\n    \"limit\" : 1000000\n}",
+									"raw": "{\n    \"q\" : \"Bosch Climo\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1982,12 +1982,18 @@
 									}
 								},
 								"url": {
-									"raw": "{{host}}{{base}}/search",
+									"raw": "{{host}}{{base}}/search?size=1000000",
 									"host": [
 										"{{host}}{{base}}"
 									],
 									"path": [
 										"search"
+									],
+									"query": [
+										{
+											"key": "size",
+											"value": "1000000"
+										}
 									]
 								}
 							},
@@ -2023,7 +2029,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"q\" : \"Bosch Climo\",\n    \"limit\" : 10,\n    \"offset\" : 100000\n}",
+									"raw": "{\n    \"q\" : \"Bosch Climo\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2031,12 +2037,18 @@
 									}
 								},
 								"url": {
-									"raw": "{{host}}{{base}}/search",
+									"raw": "{{host}}{{base}}/search?page=100000",
 									"host": [
 										"{{host}}{{base}}"
 									],
 									"path": [
 										"search"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "100000"
+										}
 									]
 								}
 							},
@@ -2082,7 +2094,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchCriteria\" : [\n        {\n            \"searchType\": \"term\",\n            \"field\": \"tags\",\n            \"values\": [\"ai\"]\n        }\n    ],\n    \"filter\" : [\"id\", \"tags\", \"type\"],\n    \"limit\" : 100,\n    \"offset\" : 0\n}",
+									"raw": "{\n    \"searchCriteria\" : [\n        {\n            \"searchType\": \"term\",\n            \"field\": \"tags\",\n            \"values\": [\"ai\"]\n        }\n    ],\n    \"filter\" : [\"id\", \"tags\", \"type\"]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2090,12 +2102,22 @@
 									}
 								},
 								"url": {
-									"raw": "{{host}}{{base}}/search",
+									"raw": "{{host}}{{base}}/search?size=100&page=1",
 									"host": [
 										"{{host}}{{base}}"
 									],
 									"path": [
 										"search"
+									],
+									"query": [
+										{
+											"key": "size",
+											"value": "100"
+										},
+										{
+											"key": "page",
+											"value": "1"
+										}
 									]
 								}
 							},
@@ -2167,7 +2189,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchCriteria\": [\n        {\n            \"searchType\": \"term\",\n            \"field\": \"type\",\n            \"values\": [\"adex:Apps\"]\n        },\n        {\n            \"searchType\": \"term\",\n            \"field\": \"tags\",\n            \"values\": [\"ai\", \"railway\"]\n        }\n    ],\n    \"filter\" : [\"id\", \"tags\"],\n    \"limit\" : 1\n}",
+									"raw": "{\n    \"searchCriteria\": [\n        {\n            \"searchType\": \"term\",\n            \"field\": \"type\",\n            \"values\": [\"adex:Apps\"]\n        },\n        {\n            \"searchType\": \"term\",\n            \"field\": \"tags\",\n            \"values\": [\"ai\", \"railway\"]\n        }\n    ],\n    \"filter\" : [\"id\", \"tags\"]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2175,12 +2197,18 @@
 									}
 								},
 								"url": {
-									"raw": "{{host}}{{base}}/search",
+									"raw": "{{host}}{{base}}/search?size=1",
 									"host": [
 										"{{host}}{{base}}"
 									],
 									"path": [
 										"search"
+									],
+									"query": [
+										{
+											"key": "size",
+											"value": "1"
+										}
 									]
 								}
 							},
@@ -2265,7 +2293,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchCriteria\": [\n        {\n            \"searchType\": \"term\",\n            \"field\": \"type\",\n            \"values\": [\"adex:DataBank\"]\n        }\n    ],\n    \"filter\" : [\"id\",\"name\",\"tags\",\"deviceId\"],\n    \"limit\" : 1000000,\n    \"offset\" : 0\n}",
+									"raw": "{\n    \"searchCriteria\": [\n        {\n            \"searchType\": \"term\",\n            \"field\": \"type\",\n            \"values\": [\"adex:DataBank\"]\n        }\n    ],\n    \"filter\" : [\"id\",\"name\",\"tags\",\"deviceId\"]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2273,12 +2301,18 @@
 									}
 								},
 								"url": {
-									"raw": "{{host}}{{base}}/search",
+									"raw": "{{host}}{{base}}/search?size=1000000",
 									"host": [
 										"{{host}}{{base}}"
 									],
 									"path": [
 										"search"
+									],
+									"query": [
+										{
+											"key": "size",
+											"value": "1000000"
+										}
 									]
 								}
 							},
@@ -2314,7 +2348,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchCriteria\": [\n        {\n            \"searchType\": \"term\",\n            \"field\": \"type\",\n            \"values\": [\"adex:DataBank\"]\n        }\n    ],\n    \"filter\" : [\"id\",\"name\",\"tags\",\"deviceId\"],\n    \"limit\" : 100,\n    \"offset\" : 1000000\n}",
+									"raw": "{\n    \"searchCriteria\": [\n        {\n            \"searchType\": \"term\",\n            \"field\": \"type\",\n            \"values\": [\"adex:DataBank\"]\n        }\n    ],\n    \"filter\" : [\"id\",\"name\",\"tags\",\"deviceId\"]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2322,12 +2356,22 @@
 									}
 								},
 								"url": {
-									"raw": "{{host}}{{base}}/search",
+									"raw": "{{host}}{{base}}/search?size=100&page=1000000",
 									"host": [
 										"{{host}}{{base}}"
 									],
 									"path": [
 										"search"
+									],
+									"query": [
+										{
+											"key": "size",
+											"value": "100"
+										},
+										{
+											"key": "page",
+											"value": "1000000"
+										}
 									]
 								}
 							},
@@ -2345,7 +2389,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchCriteria\": [\n        {\n            \"searchType\": \"term\",\n            \"field\": \"type\",\n            \"values\": [\"adex:DataBank\"]\n        },\n        {\n            \"searchType\": \"term\",\n            \"field\": \"department\",\n            \"values\": [\"Health Medical and Family Welfare\"]\n        }\n    ],\n    \"limit\" : 100\n}",
+									"raw": "{\n    \"searchCriteria\": [\n        {\n            \"searchType\": \"term\",\n            \"field\": \"type\",\n            \"values\": [\"adex:DataBank\"]\n        },\n        {\n            \"searchType\": \"term\",\n            \"field\": \"department\",\n            \"values\": [\"Health Medical and Family Welfare\"]\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2353,12 +2397,18 @@
 									}
 								},
 								"url": {
-									"raw": "{{host}}{{base}}/search",
+									"raw": "{{host}}{{base}}/search?size=100",
 									"host": [
 										"{{host}}{{base}}"
 									],
 									"path": [
 										"search"
+									],
+									"query": [
+										{
+											"key": "size",
+											"value": "100"
+										}
 									]
 								}
 							},
@@ -2407,7 +2457,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchCriteria\": [\n        {\n            \"searchType\": \"term\",\n            \"field\": \"type\",\n            \"values\": [\"adex:DataBank\"]\n        },\n        {\n            \"searchType\": \"term\",\n            \"field\": \"organizationType\",\n            \"values\": [\"Private\"]\n        }\n    ],\n    \"limit\" : 100\n}",
+									"raw": "{\n    \"searchCriteria\": [\n        {\n            \"searchType\": \"term\",\n            \"field\": \"type\",\n            \"values\": [\"adex:DataBank\"]\n        },\n        {\n            \"searchType\": \"term\",\n            \"field\": \"organizationType\",\n            \"values\": [\"Private\"]\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"


### PR DESCRIPTION
### Summary

This PR updates the `/search` API response to include a `pagination` block, enabling more effective and user-friendly paginated data handling from frontend applications.

### Changes Made

🔹 Added a `pagination` object to the response structure, which includes:
- `page`: Current page number  
- `size`: Number of results per page  
- `totalCount`: Total number of matching results  
- `totalPages`: Total number of available pages  
- `hasNext`: Indicates whether a next page exists  
- `hasPrevious`: Indicates whether a previous page exists  
---

### Sample Request:

```bash
curl --location --request POST 'https://example-cat.com/iudx/cat/v1/search?size=100&page=1' \
--header 'Content-Type: application/json' \
--data '{
  "searchCriteria": [
    {
      "searchType": "term",
      "field": "type",
      "values": ["adex:AiModel"]
    }
  ],
  "filter": ["id"]
}'
```
###  Sample Response
```json
{
  "type": "urn:dx:cat:Success",
  "title": "Success",
  "pagination": {
    "page": 1,
    "size": 100,
    "totalCount": 3,
    "totalPages": 1,
    "hasNext": false,
    "hasPrevious": false
  },
  "results": [
    { "id": "a4e3b98f-d073-4a2f-8587-e8d1718f2a89" },
    { "id": "d7d34f8d-8cd4-4a68-8a4d-3b7fc5e8bb13" },
    { "id": "2b1a2e8d-45f4-43a1-9e8e-d1f8ad1002bb" }
  ]
}
