### PR TITLE
Fix: Restore totalHits in /search response to support item deletion checks

### DIFF
--- a/src/main/java/iudx/catalogue/server/database/DatabaseServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/database/DatabaseServiceImpl.java
@@ -205,7 +205,6 @@ public class DatabaseServiceImpl implements DatabaseService {
                 .put(HAS_PREVIOUS, hasPrevious);
 
             searchRes.result().put(PAGINATION, pagination);
-            searchRes.result().remove(TOTAL_HITS);
             handler.handle(Future.succeededFuture(searchRes.result()));
           } else {
             LOGGER.error("Fail: DB Request;" + searchRes.cause().getMessage());


### PR DESCRIPTION
### This PR reintroduces the totalHits field in the /search API response.
- The field was previously removed as part of response clean-up.

- However, it is still used in internal validation logic during deletion via the /item endpoint.