### PR TITLE
Add case-insensitive wildcard query support for fileFormat field in filter post search

### DIFF
--- a/src/main/java/iudx/catalogue/server/database/Constants.java
+++ b/src/main/java/iudx/catalogue/server/database/Constants.java
@@ -43,6 +43,7 @@ public class Constants {
   public static final String DATASET = "DATASET";
   public static final String FORWARD_SLASH = "/";
   public static final String WILDCARD_KEY = "wildcard";
+  public static final String CASE_INSENSITIVE = "case_insensitive";
   public static final String AGGREGATION_ONLY = "AGGREGATION";
   public static final String AGGREGATION_LIST = "AGGREGATION_LIST";
   public static final String RATING_AGGREGATION_ONLY = "R_AGGREGATION";


### PR DESCRIPTION
- Updated `QueryDecoder.java` to use a `wildcard` query with `case_insensitive: true` for `fileFormat` field in term-based search criteria.
- Retained `match` queries for other fields as they remain consistent and support case-insensitivity.
- Added new constant `CASE_INSENSITIVE` in `Constants.java` to support the new wildcard query parameter.
- This change addresses the issue of inconsistent letter casing in the `fileFormat` values (e.g., CSV vs csv) without requiring immediate reindexing.
- Future improvements will include mapping updates with normalizers to standardize case on ingestion.