### PR TITLE
Improve Schema Validation Error Handling with Structured Response Format

### DIFF
--- a/src/main/java/iudx/catalogue/server/apiserver/CrudApis.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/CrudApis.java
@@ -31,16 +31,11 @@ import iudx.catalogue.server.auditing.util.AuditMetadata;
 import iudx.catalogue.server.authenticator.AuthenticationService;
 import iudx.catalogue.server.database.DatabaseService;
 import iudx.catalogue.server.util.Api;
-import iudx.catalogue.server.util.Constants;
 import iudx.catalogue.server.validator.ValidatorService;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/iudx/catalogue/server/validator/Validator.java
+++ b/src/main/java/iudx/catalogue/server/validator/Validator.java
@@ -1,5 +1,7 @@
 package iudx.catalogue.server.validator;
 
+import static iudx.catalogue.server.util.Constants.RESULTS;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jackson.JsonLoader;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
@@ -8,9 +10,15 @@ import com.github.fge.jsonschema.main.JsonSchema;
 import com.github.fge.jsonschema.main.JsonSchemaFactory;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -66,7 +74,7 @@ public final class Validator {
    * @param obj Json encoded string object
    * @return isValid boolean
    */
-  public Future<String> validate(String obj) {
+  public Future<String> validateSearchCriteria(String obj) {
     Promise<String> promise = Promise.promise();
     boolean isValid;
     List<String> schemaErrorList = new ArrayList<>();
@@ -94,4 +102,194 @@ public final class Validator {
     }
     return promise.future();
   }
+
+  /**
+   * Validates a JSON-encoded string against the loaded schema.
+   *
+   * <p>This method performs full JSON schema validation and collects all validation errors.
+   * It logs each error and builds a structured error response that includes:
+   * <ul>
+   *   <li>A high-level message listing all the invalid fields</li>
+   *   <li>A detailed list of human-readable validation messages for each field</li>
+   * </ul>
+   *
+   * <p>If validation passes, the returned {@link Future} is completed. If validation fails,
+   * the future is failed with a JSON-encoded {@link JsonObject} that contains:
+   * <ul>
+   *   <li><b>detail</b>: A comma-separated list of invalid fields</li>
+   *   <li><b>results</b>: An array of field-specific validation messages</li>
+   * </ul>
+   *
+   * @param obj A JSON-encoded string to validate
+   * @return a {@link Future} that is:
+   *         <ul>
+   *           <li>completed if the input is valid</li>
+   *           <li>failed with a structured error message if the input is invalid</li>
+   *         </ul>
+   */
+  public Future<String> validate(String obj) {
+    Promise<String> promise = Promise.promise();
+    List<String> schemaErrorList = new ArrayList<>();
+    Set<String> errorFields = new LinkedHashSet<>(); // Preserve order
+
+    try {
+      JsonNode jsonObj = loadString(obj);
+      ProcessingReport report = schema.validate(jsonObj);
+
+      report.forEach(msg -> {
+        if ("error".equalsIgnoreCase(msg.getLogLevel().toString())) {
+          JsonNode msgNode = msg.asJson();
+
+          String pointer = "";
+          if (msgNode.has("instance") && msgNode.get("instance").has("pointer")) {
+            pointer = msgNode.get("instance").get("pointer").asText(); // e.g., "/accessPolicy"
+          }
+
+          String errorMessage =
+              msgNode.has("message") ? msgNode.get("message").asText() : "Validation failed";
+
+          // Beautify pointer
+          //String field = pointer.isEmpty() ? "Unknown field" : pointer.substring(1); // remove
+          String field;
+          if (!pointer.isEmpty()) {
+            field = pointer.substring(1); // e.g., "/mediaURL" => "mediaURL"
+          } else if (errorMessage.contains("missing required properties")) {
+            Matcher matcher = Pattern.compile("\\[\"(.*?)\"\\]").matcher(errorMessage);
+            if (matcher.find()) {
+              field = matcher.group(1);
+            } else {
+              field = "Unknown field";
+            }
+          } else {
+            field = "Unknown field";
+          }
+          // leading slash
+          errorFields.add(field);
+
+          String userMessage = String.format("Field \"%s\": %s", field, errorMessage);
+          LOGGER.error(userMessage);
+          schemaErrorList.add(userMessage);
+        }
+      });
+
+      if (report.isSuccess()) {
+        promise.complete();
+      } else {
+        String fieldListStr = String.join(", ", errorFields);
+        String detailMessage = "Schema validation failed for fields: " + fieldListStr;
+
+        JsonObject errorResponse = new JsonObject()
+            .put("detail", detailMessage)
+            .put(RESULTS, parseValidationMessages(schemaErrorList.toString()));
+
+        promise.fail(errorResponse.encode());
+      }
+
+    } catch (IOException | ProcessingException e) {
+      LOGGER.error("Exception during validation", e);
+      promise.fail(e.getMessage());
+    }
+
+    return promise.future();
+  }
+
+  private JsonArray parseValidationMessages(String rawMessage) {
+    JsonArray userMessages = new JsonArray();
+
+    String[] rawMessages = rawMessage.replaceAll("^\\[|\\]$", "")
+        .split(",(?=\\s*Field)");
+
+    for (String msg : rawMessages) {
+      msg = msg.trim().replaceAll("\\\\\"", "\"").replaceAll("\\\\", "");
+
+      String fieldName = null;
+      Matcher fieldMatcher = Pattern.compile("Field\\s+\"([^\"]+)\"").matcher(msg);
+      if (fieldMatcher.find()) {
+        fieldName = fieldMatcher.group(1);
+        // Remove repeated "Field \"fieldName\":" prefix from message if present
+        msg = msg.replaceFirst("Field\\s+\"" + Pattern.quote(fieldName) + "\"\\s*:\\s*", "").trim();
+      }
+
+      if (msg.contains("ECMA 262 regex")) {
+        if (msg.contains(
+            "^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$")) {
+          userMessages.add(
+              String.format("Field \"%s\": does not match pattern for UUID.", fieldName));
+
+        } else if (msg.contains("^(RESTRICTED|OPEN|PRIVATE)$")) {
+          userMessages.add(String.format(
+              "Field \"%s\": must be one of: \"RESTRICTED\", \"OPEN\", or \"PRIVATE\".",
+              fieldName));
+
+        } else {
+          userMessages.add(
+              String.format("Field \"%s\": does not match required format.", fieldName));
+        }
+
+      } else if (msg.contains("missing required properties")) {
+        Matcher matcher = Pattern.compile("\\[\"(.*?)\"\\]").matcher(msg);
+        if (matcher.find()) {
+          userMessages.add("Field \"" + matcher.group(1) + "\": is required.");
+        } else {
+          userMessages.add("A required field is missing.");
+        }
+
+      } else if (msg.contains("not found in enum")) {
+        Matcher matcher =
+            Pattern.compile("instance value \\(\"(.*?)\"\\).*?values: \\[(.*?)\\]").matcher(msg);
+        if (matcher.find()) {
+          String rawEnumValues = matcher.group(2);
+
+          // Quote all values including empty string
+          List<String> valuesList = new ArrayList<>();
+          for (String val : rawEnumValues.split(",")) {
+            val = val.trim().replaceAll("^\"|\"$", "");
+            valuesList.add(val.isEmpty() ? "\"\"" : "\"" + val + "\"");
+          }
+
+          String formattedEnumValues = String.join(", ", valuesList);
+          userMessages.add(
+              String.format("Field \"%s\": must be one of: %s.", fieldName, formattedEnumValues));
+
+        } else {
+          userMessages.add(String.format("Field \"%s\": contains an invalid value.", fieldName));
+        }
+
+      } else if (msg.matches(
+          ".*instance type \\(.*\\) does not match any allowed primitive type.*")) {
+        // Handle type mismatch messages
+        Matcher matcher =
+            Pattern.compile("instance type \\((.*?)\\).*allowed: \\[(.*?)\\]").matcher(msg);
+        if (matcher.find()) {
+          String foundType = matcher.group(1);
+          String allowedTypes =
+              matcher.group(2).replaceAll("\"", ""); // Remove quotes from allowed types
+          userMessages.add(String.format("Field \"%s\": expected type %s, but found %s.", fieldName,
+              allowedTypes, foundType));
+        } else {
+          userMessages.add(String.format("Field \"%s\": has a type mismatch.", fieldName));
+        }
+      } else if (msg.matches(".*is too long \\(length: \\d+, maximum allowed: \\d+\\).*")) {
+        Matcher matcher = Pattern.compile("length: (\\d+), maximum allowed: (\\d+)").matcher(msg);
+        if (matcher.find()) {
+          String actualLength = matcher.group(1);
+          String maxLength = matcher.group(2);
+          userMessages.add(String.format(
+              "Field \"%s\": exceeds maximum allowed length of %s characters (provided: %s).",
+              fieldName, maxLength, actualLength));
+        } else {
+          userMessages.add(
+              String.format("Field \"%s\": exceeds maximum allowed length.", fieldName));
+        }
+
+      } else {
+        userMessages.add(
+            "Field " + (fieldName != null ? "\"" + fieldName + "\"" : "unknown") + ": " + msg);
+      }
+    }
+
+    return userMessages;
+  }
+
+
 }

--- a/src/main/java/iudx/catalogue/server/validator/ValidatorServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/validator/ValidatorServiceImpl.java
@@ -235,7 +235,7 @@ public class ValidatorServiceImpl implements ValidatorService {
               LOGGER.error("Fail: Invalid Schema");
               LOGGER.error(x.getMessage());
               handler.handle(
-                  Future.failedFuture(String.valueOf(new JsonArray().add(x.getMessage()))));
+                  Future.failedFuture((x.getMessage())));
             });
   }
 
@@ -797,19 +797,19 @@ public class ValidatorServiceImpl implements ValidatorService {
       Future<String> validationFuture;
       switch (searchType) {
         case TERM:
-          validationFuture = termValidator.validate(criterion.encode());
+          validationFuture = termValidator.validateSearchCriteria(criterion.encode());
           break;
 
         case BETWEEN_RANGE:
         case BEFORE_RANGE:
         case AFTER_RANGE:
-          validationFuture = rangeValidator.validate(criterion.encode());
+          validationFuture = rangeValidator.validateSearchCriteria(criterion.encode());
           break;
 
         case BETWEEN_TEMPORAL:
         case BEFORE_TEMPORAL:
         case AFTER_TEMPORAL:
-          validationFuture = temporalValidator.validate(criterion.encode());
+          validationFuture = temporalValidator.validateSearchCriteria(criterion.encode());
           break;
 
         default:
@@ -847,7 +847,7 @@ public class ValidatorServiceImpl implements ValidatorService {
 
   public ValidatorService validateGeoSearchQuery(JsonObject request,
                                                  Handler<AsyncResult<JsonObject>> handler) {
-    isValidSchema = geoSearchQueryValidator.validate(request.toString());
+    isValidSchema = geoSearchQueryValidator.validateSearchCriteria(request.toString());
 
     SearchQueryValidatorHelper.handleGeoSearchValidationResult(isValidSchema, request, handler);
     return this;
@@ -855,7 +855,7 @@ public class ValidatorServiceImpl implements ValidatorService {
 
   public ValidatorService validateTextSearchQuery(JsonObject request,
                                                   Handler<AsyncResult<JsonObject>> handler) {
-    isValidSchema = textSearchQueryValidator.validate(request.toString());
+    isValidSchema = textSearchQueryValidator.validateSearchCriteria(request.toString());
 
     SearchQueryValidatorHelper.handleTextSearchValidationResult(isValidSchema, request, handler);
     return this;
@@ -863,7 +863,7 @@ public class ValidatorServiceImpl implements ValidatorService {
 
   public ValidatorService validateFilterSearchQuery(JsonObject request,
                                                     Handler<AsyncResult<JsonObject>> handler) {
-    isValidSchema = filterSearchQueryValidator.validate(request.toString());
+    isValidSchema = filterSearchQueryValidator.validateSearchCriteria(request.toString());
 
     SearchQueryValidatorHelper.handleFilterSearchValidationResult(isValidSchema, request, handler);
     return this;


### PR DESCRIPTION
### Summary

This PR enhances the **JSON schema validation flow** by improving the structure and clarity of error responses when validation fails. It provides detailed field-level error reporting and introduces a cleaner separation of validation methods.

---

### 🔧 Key Changes

#### 🔍 `Validator.java`
- Refactored `validate()` method to:
  - Extract invalid field names from the schema validation report.
  - Parse and transform raw validation messages into human-readable format.
  - Construct a structured JSON error response containing:
    - `"detail"`: Comma-separated list of invalid fields.
    - `"results"`: Array of detailed field-level error messages.
- Introduced a new method `validateSearchCriteria()` that retains the original simple validation flow (returns raw messages). Being used for search endpoint's payload validation.

#### 🌐 `CrudApis.java`
- Updated schema validation error handling in the request handler.
- Now parses the structured error `JsonObject` and uses:
  - `detail` for `withDetail()`
  - `results` for `withResult()`

#### 📦 `ValidatorServiceImpl.java`
- Replaced calls to `validate()` with `validateSearchCriteria()` for:
  - Term, Range, Temporal search validation.
  - Geo/Text/Filter search validators.
- Ensures backward-compatible use of the refactored validation logic.

---

### 💡 Benefits

- API consumers receive **clear, actionable schema validation feedback**.
- Responses now include:
  - The **fields that failed** validation.
  - **Detailed messages** describing why each field is invalid.
- Makes debugging and client-side corrections easier.
- Provides consistency across different validation flows.

---

### 📁 Affected Components

- `Validator.java`
- `ValidatorServiceImpl.java`
- `CrudApis.java`

---

### 🧪 Example Error Response

```json
{
  "type": "urn:dx:cat:InvalidSchema",
  "title": "Invalid Schema",
  "detail": "Schema validation failed for fields: accessPolicy, organizationId",
  "results": [
    "Field \"accessPolicy\": must be one of: \"RESTRICTED\", \"OPEN\", or \"PRIVATE\".",
    "Field \"organizationId\": does not match pattern for UUID."
  ]
}
