### PR TITLE
Fix: Use match_phrase for strict tag matching in post search API

### DIFF
--- a/src/main/java/iudx/catalogue/server/database/Constants.java
+++ b/src/main/java/iudx/catalogue/server/database/Constants.java
@@ -257,6 +257,7 @@ public class Constants {
   public static final String MUST_NOT_QUERY = "{\"bool\":{\"must_not\":$1}}";
   public static final String FILTER_QUERY = "{\"bool\":{\"filter\":[$1]}}";
   public static final String MATCH_QUERY = "{\"match\":{\"$1\":\"$2\"}}";
+  public static final String MATCH_PHRASE_QUERY = "{\"match_phrase\":{\"$1\":\"$2\"}}";
   public static final String FUZZY_MATCH_QUERY = "{ \"match\": { \"$1\": { \"query\": "
       + "\"$2\", \"fuzziness\": \"AUTO\", \"operator\": \"or\" }}}";
   public static final String TERM_QUERY = "{\"term\":{\"$1\":\"$2\"}}";

--- a/src/main/java/iudx/catalogue/server/database/QueryDecoder.java
+++ b/src/main/java/iudx/catalogue/server/database/QueryDecoder.java
@@ -273,13 +273,22 @@ public final class QueryDecoder {
                 String matchQuery;
 
                 // raw field matches (e.g. tags, description, location)
-                if (TAGS.equals(field) || DESCRIPTION_ATTR.equals(field)
+                if (DESCRIPTION_ATTR.equals(field)
                     || field.startsWith(LOCATION)) {
                   matchQuery = MATCH_QUERY.replace("$1", field).replace("$2", value);
                   shouldQuery.add(new JsonObject(matchQuery));
 
                   if ("true".equals(request.getString(FUZZY))
-                      && (TAGS.equals(field) || DESCRIPTION_ATTR.equals(field))) {
+                      && DESCRIPTION_ATTR.equals(field)) {
+                    matchQuery = FUZZY_MATCH_QUERY.replace("$1", field)
+                        .replace("$2", value);
+                    shouldQuery.add(new JsonObject(matchQuery));
+                  }
+                } else if (TAGS.equals(field)) {
+                  matchQuery = MATCH_PHRASE_QUERY.replace("$1", field).replace("$2", value);
+                  shouldQuery.add(new JsonObject(matchQuery));
+
+                  if ("true".equals(request.getString(FUZZY))) {
                     matchQuery = FUZZY_MATCH_QUERY.replace("$1", field)
                         .replace("$2", value);
                     shouldQuery.add(new JsonObject(matchQuery));


### PR DESCRIPTION
### Summary

This PR updates the catalogue search query logic to use `match_phrase` instead of `match` for the `tags` field in the `/search` API.

### Why the change?

Previously, we were using `match` queries which tokenize the input string and perform partial word-based matching. This caused irrelevant results to appear when the tags partially overlapped (e.g., `Ticketing` matched documents with `Online Ticketing`, `Ticketing Info`, etc.).

As per feedback, we now use `match_phrase` to ensure strict phrase-level matching. Only documents containing the **exact tag phrase** (e.g., `"Offline Ticketing"`) will be matched.

### Changes Made

- Replaced `match` with `match_phrase` for `tags` field inside search criteria
- No changes to query structure or interface; behavior is now stricter and more accurate

### Impact

- Improves accuracy of tag-based search
- Prevents loosely related items from appearing in the results
