### PR TITLE
Refactor: Use paginationInfo in CAT search api response format (aligned with acl)

### DIFF
--- a/src/main/java/iudx/catalogue/server/database/Constants.java
+++ b/src/main/java/iudx/catalogue/server/database/Constants.java
@@ -315,7 +315,7 @@ public class Constants {
   public static final String TOTAL_PAGES = "totalPages";
   public static final String HAS_NEXT = "hasNext";
   public static final String HAS_PREVIOUS = "hasPrevious";
-  public static final String PAGINATION = "pagination";
+  public static final String PAGINATION_INFO = "paginationInfo";
   static final int STATIC_DELAY_TIME = 3000;
   /* Database */
   static final String AGGREGATION_KEY = "aggs";

--- a/src/main/java/iudx/catalogue/server/database/DatabaseServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/database/DatabaseServiceImpl.java
@@ -2,7 +2,6 @@ package iudx.catalogue.server.database;
 
 import static iudx.catalogue.server.database.Constants.*;
 import static iudx.catalogue.server.util.Constants.*;
-import static java.lang.Math.floor;
 
 import io.vertx.core.*;
 import io.vertx.core.json.JsonArray;
@@ -196,7 +195,7 @@ public class DatabaseServiceImpl implements DatabaseService {
             boolean hasNext = totalHits > 0 && page < totalPages;
             boolean hasPrevious = page > 1 && page <= totalPages;
 
-            JsonObject pagination = new JsonObject()
+            JsonObject paginationInfo = new JsonObject()
                 .put(PAGE_KEY, page)
                 .put(SIZE_KEY, size)
                 .put(TOTAL_COUNT, totalHits)
@@ -204,7 +203,7 @@ public class DatabaseServiceImpl implements DatabaseService {
                 .put(HAS_NEXT, hasNext)
                 .put(HAS_PREVIOUS, hasPrevious);
 
-            searchRes.result().put(PAGINATION, pagination);
+            searchRes.result().put(PAGINATION_INFO, paginationInfo);
             handler.handle(Future.succeededFuture(searchRes.result()));
           } else {
             LOGGER.error("Fail: DB Request;" + searchRes.cause().getMessage());


### PR DESCRIPTION
### Summary

This PR updates the CAT API response format to use `paginationInfo` instead of `pagination`, to align with the structure used in the ACL.
