### PR TITLE
feat: add /search/myassets endpoint to support user-specific asset discovery

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -399,6 +399,44 @@ paths:
               ],
               "filter": ["id", "type", "department", "itemCreatedAt", "dataReadiness"]
             }'
+  /search/myassets:
+    post:
+      summary: Search assets created by the current authenticated user
+      description: >
+        Returns assets owned by the current authenticated user, using the same
+        unified search format as the `/search` endpoint. This endpoint automatically
+        filters results to only include items where `ownerUserId` matches the
+        authenticated user's `sub` value from the token.
+
+        Supports property-based, temporal, and numeric range filters, as well as
+        full-text search.
+      operationId: myAssetsSearch
+      tags:
+        - Discovery
+      security:
+        - authorization: [ ]
+      requestBody:
+        description: Request body containing unified search filters
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchCriteriaRequest'
+      responses:
+        '200':
+          description: A successful search response with assets owned by the user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchResponse'
+        '400':
+          description: Invalid request query
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Missing or invalid authentication token
   /count:
     post:
       tags:
@@ -928,6 +966,11 @@ tags:
       These apis are intended to be used by User Interfaces.
     x-displayName: List
 components:
+  securitySchemes:
+    authorization:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     successResponseWithObjects:
       type: object

--- a/src/main/java/iudx/catalogue/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/ApiServerVerticle.java
@@ -390,6 +390,25 @@ public class ApiServerVerticle extends AbstractVerticle {
               }
               searchApis.postSearchHandler(routingContext);
             });
+    router
+        .post(api.getRouteSearchMyAssets())
+        .produces(MIME_APPLICATION_JSON)
+        .failureHandler(exceptionhandler)
+        .handler(
+            routingContext -> {
+              /* checking auhthentication info in requests */
+              if (routingContext.request().headers().contains(HEADER_AUTHORIZATION)) {
+                String authHeader = routingContext.request().getHeader(HEADER_AUTHORIZATION);
+                if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                  String token = authHeader.substring("Bearer ".length()).trim();
+                  routingContext.put(HEADER_TOKEN, token);
+                }
+                searchApis.postSearchHandler(routingContext);
+              } else {
+                LOGGER.warn("Fail: Unathorized CRUD operation");
+                routingContext.response().setStatusCode(401).end();
+              }
+            });
 
     /* NLP Search */
     router

--- a/src/main/java/iudx/catalogue/server/apiserver/SearchApis.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/SearchApis.java
@@ -262,8 +262,6 @@ public final class SearchApis {
     requestBody.put(PAGE_KEY, page);
     requestBody.put(OFFSET, offset);
 
-    LOGGER.debug(request.params().toString());
-
     QueryMapper.extractSortFromRawUri(routingContext.request().uri(), requestBody);
 
     String token = routingContext.get(HEADER_TOKEN);
@@ -271,7 +269,7 @@ public final class SearchApis {
       JsonObject jwtAuthenticationInfo = new JsonObject()
           .put(TOKEN, token)
           .put(METHOD, REQUEST_GET)
-          .put(API_ENDPOINT, api.getRouteSearch());
+          .put(API_ENDPOINT, routingContext.normalizedPath());
 
       authService.tokenInterospect(new JsonObject(), jwtAuthenticationInfo, authHandler -> {
         if (authHandler.failed()) {
@@ -361,7 +359,8 @@ public final class SearchApis {
             .end(validateHandler.cause().getLocalizedMessage());
       } else {
         String path = request.path();
-        if (path.equals(api.getRouteSearch())) {
+        requestBody.put(MY_ASSETS_REQ, path.equals(api.getRouteSearchMyAssets()));
+        if (path.equals(api.getRouteSearch()) || path.equals(api.getRouteSearchMyAssets())) {
           dbService.searchQuery(requestBody, handler -> {
             if (handler.succeeded()) {
               JsonObject resultJson = handler.result();

--- a/src/main/java/iudx/catalogue/server/apiserver/util/Constants.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/util/Constants.java
@@ -64,6 +64,7 @@ public class Constants {
 
   public static final String ROUTE_RELATIONSHIP = "/relationship";
   public static final String ROUTE_SEARCH = "/search";
+  public static final String ROUTE_SEARCH_MY_ASSETS = "/search/myassets";
   public static final String ROUTE_NLP_SEARCH = "/nlpsearch";
   public static final String ROUTE_LIST_ITEMS = "/list/:itemType";
   public static final String ROUTE_LIST = "/list";

--- a/src/main/java/iudx/catalogue/server/authenticator/KcAuthenticationServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/authenticator/KcAuthenticationServiceImpl.java
@@ -185,6 +185,7 @@ public class KcAuthenticationServiceImpl implements AuthenticationService {
         || endpoint.equals(api.getRouteMlayerInstance())
         || endpoint.equals(api.getRouteMlayerDomains())
         || endpoint.equals(api.getRouteSearch())
+        || endpoint.equals(api.getRouteSearchMyAssets())
         || endpoint.equals(api.getRouteListMulItems())) {
       promise.complete(true);
     } else {

--- a/src/main/java/iudx/catalogue/server/authenticator/authorization/CosAdminAuthStrategy.java
+++ b/src/main/java/iudx/catalogue/server/authenticator/authorization/CosAdminAuthStrategy.java
@@ -46,6 +46,7 @@ public class CosAdminAuthStrategy implements AuthorizationStratergy {
     accessList.add(new AuthorizationRequest(PUT, api.getRouteItems(), ITEM_TYPE_RESOURCE_SERVER));
     accessList.add(
         new AuthorizationRequest(DELETE, api.getRouteItems(), ITEM_TYPE_RESOURCE_SERVER));
+    accessList.add(new AuthorizationRequest(POST, api.getRouteSearchMyAssets(), ITEM_TYPE_APPS));
     accessList.add(new AuthorizationRequest(POST, api.getRouteItems(), ITEM_TYPE_APPS));
     accessList.add(new AuthorizationRequest(PUT, api.getRouteItems(), ITEM_TYPE_APPS));
     accessList.add(new AuthorizationRequest(DELETE, api.getRouteItems(), ITEM_TYPE_APPS));

--- a/src/main/java/iudx/catalogue/server/authenticator/authorization/ProviderAuthStrategy.java
+++ b/src/main/java/iudx/catalogue/server/authenticator/authorization/ProviderAuthStrategy.java
@@ -2,6 +2,7 @@ package iudx.catalogue.server.authenticator.authorization;
 
 import static iudx.catalogue.server.authenticator.authorization.Method.*;
 import static iudx.catalogue.server.util.Constants.ITEM_TYPE_AI_MODEL;
+import static iudx.catalogue.server.util.Constants.ITEM_TYPE_APPS;
 import static iudx.catalogue.server.util.Constants.ITEM_TYPE_DATA_BANK;
 import static iudx.catalogue.server.util.Constants.ITEM_TYPE_RESOURCE;
 import static iudx.catalogue.server.util.Constants.ITEM_TYPE_RESOURCE_GROUP;
@@ -39,6 +40,8 @@ public class ProviderAuthStrategy implements AuthorizationStratergy {
     // /item access list
     accessList.add(new AuthorizationRequest(POST, api.getRouteItems(), ITEM_TYPE_RESOURCE_GROUP));
     accessList.add(new AuthorizationRequest(POST, api.getRouteItems(), ITEM_TYPE_RESOURCE));
+    accessList.add(new AuthorizationRequest(POST, api.getRouteSearchMyAssets(), ITEM_TYPE_AI_MODEL));
+    accessList.add(new AuthorizationRequest(POST, api.getRouteSearchMyAssets(), ITEM_TYPE_DATA_BANK));
     accessList.add(new AuthorizationRequest(POST, api.getRouteItems(), ITEM_TYPE_AI_MODEL));
     accessList.add(new AuthorizationRequest(POST, api.getRouteItems(), ITEM_TYPE_DATA_BANK));
     accessList.add(new AuthorizationRequest(PUT, api.getRouteItems(), ITEM_TYPE_RESOURCE_GROUP));

--- a/src/main/java/iudx/catalogue/server/util/Api.java
+++ b/src/main/java/iudx/catalogue/server/util/Api.java
@@ -16,6 +16,7 @@ public class Api {
   private StringBuilder routeInstance;
   private StringBuilder routeRelationship;
   private StringBuilder routeSearch;
+  private StringBuilder routeSearchMyAssets;
   private StringBuilder routeNlpSearch;
   private StringBuilder routeListItems;
   private StringBuilder routeListMulItems;
@@ -66,6 +67,7 @@ public class Api {
     routeInstance = new StringBuilder(dxApiBasePath).append(ROUTE_INSTANCE);
     routeRelationship = new StringBuilder(dxApiBasePath).append(ROUTE_RELATIONSHIP);
     routeSearch = new StringBuilder(dxApiBasePath).append(ROUTE_SEARCH);
+    routeSearchMyAssets = new StringBuilder(dxApiBasePath).append(ROUTE_SEARCH_MY_ASSETS);
     routeNlpSearch = new StringBuilder(dxApiBasePath).append(ROUTE_NLP_SEARCH);
     routeListItems = new StringBuilder(dxApiBasePath).append(ROUTE_LIST_ITEMS);
     routeListMulItems = new StringBuilder(dxApiBasePath).append(ROUTE_LIST);
@@ -111,6 +113,9 @@ public class Api {
 
   public String getRouteSearch() {
     return routeSearch.toString();
+  }
+  public String getRouteSearchMyAssets() {
+    return routeSearchMyAssets.toString();
   }
 
   public String getRouteNlpSearch() {

--- a/src/main/java/iudx/catalogue/server/util/Constants.java
+++ b/src/main/java/iudx/catalogue/server/util/Constants.java
@@ -62,6 +62,7 @@ public class Constants {
   public static final String COS = "cos";
   public static final String OWNER = "owner";
   public static final String PROVIDER_USER_ID = "ownerUserId";
+  public static final String MY_ASSETS_REQ = "myAssetsRequest";
   public static final String RESOURCE_SERVER_URL = "resourceServerRegURL";
   public static final String COS_ITEM = "cos";
   public static final String AI_MODEL = "aiModel";

--- a/src/test/resources/AI Sandbox - CAT.postman_collection.json
+++ b/src/test/resources/AI Sandbox - CAT.postman_collection.json
@@ -3356,6 +3356,61 @@
 					"response": []
 				}
 			]
+		},
+		{
+			"name": "My Assets",
+			"item": [
+				{
+					"name": "MyAssetsSearch (200)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{org_admin_token}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"searchCriteria\": [\n    {\n        \"searchType\": \"term\",\n        \"field\": \"type\",\n        \"values\": [\"adex:DataBank\", \"adex:Apps\", \"adex:AiModel\"]\n    }\n  ]\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}{{base}}/search/myassets?sort=itemCreatedAt:asc;name:desc&page=1&size=1000",
+							"host": [
+								"{{host}}{{base}}"
+							],
+							"path": [
+								"search",
+								"myassets"
+							],
+							"query": [
+								{
+									"key": "sort",
+									"value": "itemCreatedAt:asc;name:desc"
+								},
+								{
+									"key": "page",
+									"value": "1"
+								},
+								{
+									"key": "size",
+									"value": "1000"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
 		}
 	]
 }


### PR DESCRIPTION
### Summary
This PR introduces a new endpoint `/search/myassets` that allows authenticated users to query assets they own. The endpoint behaves identically to the existing `/search` API in terms of query structure and supports all unified search formats (term, temporal, range, and text).

### Key Changes
- Added `/search/myassets` route in the router.
- Extracted `sub` from the JWT token and used it to filter items where `ownerUserId == sub`.
- Introduced a conditional flag `MY_ASSETS_REQ=true` in the request object to toggle access control behavior inside the query builder.
- Applied bearer token-based security for this endpoint.
- Updated OpenAPI documentation to include `/search/myassets` with appropriate security and request schema references.

### Usage
Requires a valid Bearer token in the `Authorization` header.  
Returns only those catalogue items where the logged-in user is the owner.

### Related Discussions
As per Gokul's suggestion, this is intended for the "My Assets" view on the user dashboard, removing the need for client-side filtering by `ownerUserId`.

