### PR TITLE
Filter out incomplete DataBank items using dataUploadStatus flag across catalogue search, count and list APIs

### DIFF
--- a/configs/indices-mappings/cat_mappings.json
+++ b/configs/indices-mappings/cat_mappings.json
@@ -291,8 +291,7 @@
                 "fields": {
                     "keyword": {
                         "type": "keyword",
-                        "ignore_above": 256,
-                        "normalizer": "case_insensitive_sort"
+                        "ignore_above": 256
                     }
                 }
             },
@@ -435,10 +434,12 @@
                 "fields": {
                     "keyword": {
                         "type": "keyword",
-                        "ignore_above": 256,
-                        "normalizer": "case_insensitive_sort"
+                        "ignore_above": 256
                     }
                 }
+            },
+            "dataUploadStatus": {
+                "type": "boolean"
             },
             "owner": {
                 "type": "text",

--- a/src/main/java/iudx/catalogue/server/validator/Constants.java
+++ b/src/main/java/iudx/catalogue/server/validator/Constants.java
@@ -11,6 +11,7 @@ public class Constants {
   public static final String ITEM_STATUS = "itemStatus";
   public static final String ACTIVE = "ACTIVE";
   public static final String ITEM_CREATED_AT = "itemCreatedAt";
+  public static final String DATA_UPLOAD_STATUS = "dataUploadStatus";
   public static final String LAST_UPDATED = "lastUpdated";
   public static final String CONTEXT = "@context";
 

--- a/src/main/java/iudx/catalogue/server/validator/ValidatorServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/validator/ValidatorServiceImpl.java
@@ -352,6 +352,9 @@ public class ValidatorServiceImpl implements ValidatorService {
 
     request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getPrettyLastUpdatedForUI())
         .put(ITEM_CREATED_AT, getUtcDatetimeAsString());
+    if (method.equalsIgnoreCase(REQUEST_POST)) {
+      request.put(DATA_UPLOAD_STATUS, false);
+    }
 
     String checkQuery = ITEM_WITH_NAME_EXISTS_QUERY
         .replace("$1", ITEM_TYPE_DATA_BANK).replace("$2", request.getString(NAME));

--- a/src/main/resources/iudx/catalogue/server/validator/adexDataBankResourceItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/adexDataBankResourceItemSchema.json
@@ -192,6 +192,12 @@
     "@context": {
       "type": "string",
       "format": "uri"
+    },
+    "dataUploadStatus": {
+      "type": "boolean",
+      "title": "Indicates whether data has been successfully uploaded",
+      "description": "This field is set by the server once data is uploaded and report generation is successful.",
+      "default": false
     }
   },
   "additionalProperties": true


### PR DESCRIPTION
### Summary
This PR introduces backend support to enforce filtering of DataBank items based on their `dataUploadStatus`. As per the recent requirement, catalogue queries must exclude any `adex:DataBank` item that hasn't completed the data upload and report generation process.

### Key Changes
- Added a `must_not` clause to all search-like queries (`searchQuery`, `listMultipleItemTypesQuery`, etc.) to exclude:
  - Items where `type=adex:DataBank`
  - And `dataUploadStatus=false`
- This filtering is applied universally, without requiring any input from the client.
- Ensures that only fully populated and verified DataBank items are returned in results.
