### PR TITLE
Add dataUploadStatus filter for AIModel items; make mediaURL optional for AIModel

### DIFF
--- a/src/main/java/iudx/catalogue/server/validator/Constants.java
+++ b/src/main/java/iudx/catalogue/server/validator/Constants.java
@@ -12,6 +12,7 @@ public class Constants {
   public static final String ACTIVE = "ACTIVE";
   public static final String ITEM_CREATED_AT = "itemCreatedAt";
   public static final String DATA_UPLOAD_STATUS = "dataUploadStatus";
+  public static final String MEDIA_URL = "mediaURL";
   public static final String LAST_UPDATED = "lastUpdated";
   public static final String CONTEXT = "@context";
 

--- a/src/main/java/iudx/catalogue/server/validator/ValidatorServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/validator/ValidatorServiceImpl.java
@@ -317,6 +317,11 @@ public class ValidatorServiceImpl implements ValidatorService {
 
     request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getPrettyLastUpdatedForUI())
         .put(ITEM_CREATED_AT, getUtcDatetimeAsString());
+    if (request.containsKey(MEDIA_URL) && !request.getString(MEDIA_URL).isBlank()) {
+      request.put(DATA_UPLOAD_STATUS, true);
+    } else {
+      request.put(DATA_UPLOAD_STATUS, false);
+    }
 
     String checkQuery = ITEM_WITH_NAME_EXISTS_QUERY
         .replace("$1", ITEM_TYPE_AI_MODEL).replace("$2", request.getString(NAME));
@@ -352,7 +357,9 @@ public class ValidatorServiceImpl implements ValidatorService {
 
     request.put(ITEM_STATUS, ACTIVE).put(LAST_UPDATED, getPrettyLastUpdatedForUI())
         .put(ITEM_CREATED_AT, getUtcDatetimeAsString());
-    if (method.equalsIgnoreCase(REQUEST_POST)) {
+    if (request.containsKey(MEDIA_URL) && !request.getString(MEDIA_URL).isBlank()) {
+      request.put(DATA_UPLOAD_STATUS, true);
+    } else {
       request.put(DATA_UPLOAD_STATUS, false);
     }
 

--- a/src/main/resources/iudx/catalogue/server/validator/adexAiModelItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/adexAiModelItemSchema.json
@@ -40,7 +40,6 @@
     "organizationType",
     "organizationId",
     "modelType",
-    "mediaURL",
     "fileFormat",
     "industry",
     "license",
@@ -201,6 +200,16 @@
       "title": "The @context schema",
       "description": "JSON-LD context URI",
       "format": "uri"
+    },
+    "dataUploadStatus": {
+      "type": "boolean",
+      "title": "Indicates whether data has been successfully uploaded",
+      "description": "This field is set by the server once data is uploaded and report generation is successful.",
+      "default": false
+    },
+    "mediaURL": {
+      "type": "string",
+      "description": "URL to the external resource"
     }
   },
   "additionalProperties": true

--- a/src/main/resources/iudx/catalogue/server/validator/adexDataBankResourceItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/adexDataBankResourceItemSchema.json
@@ -198,6 +198,10 @@
       "title": "Indicates whether data has been successfully uploaded",
       "description": "This field is set by the server once data is uploaded and report generation is successful.",
       "default": false
+    },
+    "mediaURL": {
+      "type": "string",
+      "description": "URL to the external resource"
     }
   },
   "additionalProperties": true


### PR DESCRIPTION
### Summary
This PR introduces two key updates related to data completeness and searching behavior:

---
### 1. AiModel Schema and Onboarding Updates
- `mediaURL` is no longer a mandatory field in the AiModel schema.
- During creation of AiModel and DataBank items:
  - If `mediaURL` is present and non-empty, `dataUploadStatus = true`
  - Otherwise, it defaults to `false`

### 2. Search Filtering Based on `dataUploadStatus`
- Catalogue APIs were excluding:
  - `adex:DataBank` items with `dataUploadStatus = false`
- Catalogue APIs now exclude:
  - `adex:AIModel` items with `dataUploadStatus = false` too.
- This filtering is applied at the query layer (`search`, `list`, `count`, etc.) via a `must_not` clause.
- Logic is modular and can be extended to other types if needed.

---
