### PR TITLE
add org_id and org_name to the audit logs and count api 401 fix

### DIFF
--- a/src/main/java/iudx/catalogue/server/apiserver/CrudApis.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/CrudApis.java
@@ -332,7 +332,9 @@ public final class CrudApis {
                             valhandler.result().getString(SHORTDESCRIPTION),
                             api.getRouteItems(), REQUEST_POST, itemType, itemName,
                             authHandler.result().getString(USER_ID),
-                            authHandler.result().getString(USER_ROLE)));
+                            authHandler.result().getString(USER_ROLE),
+                            authHandler.result().getString(ORGANIZATION_ID),
+                            authHandler.result().getString(ORGANIZATION_NAME)));
                       }
                     }
                   });
@@ -353,7 +355,9 @@ public final class CrudApis {
                             valhandler.result().getString(SHORTDESCRIPTION),
                             api.getRouteItems(), REQUEST_PUT, itemType, itemName,
                             authHandler.result().getString(USER_ID),
-                            authHandler.result().getString(USER_ROLE)));
+                            authHandler.result().getString(USER_ROLE),
+                            authHandler.result().getString(ORGANIZATION_ID),
+                            authHandler.result().getString(ORGANIZATION_NAME)));
                       }
                     } else if (dbhandler.failed()) {
                       LOGGER.error("Fail: Item update;" + dbhandler.cause().getMessage());
@@ -436,7 +440,9 @@ public final class CrudApis {
                 if (hasAuditService) {
                   updateAuditTable(new AuditMetadata(itemId, shortDescription, api.getRouteItems(),
                       REQUEST_GET, itemType, itemName, authHandler.result().getString(USER_ID),
-                      authHandler.result().getString(USER_ROLE)));
+                      authHandler.result().getString(USER_ROLE),
+                      authHandler.result().getString(ORGANIZATION_ID),
+                      authHandler.result().getString(ORGANIZATION_NAME)));
                 }
               }
             } else {
@@ -613,7 +619,9 @@ public final class CrudApis {
                     updateAuditTable(new AuditMetadata(itemId, shortDescription,
                         api.getRouteItems(), REQUEST_DELETE, itemType, itemName,
                         authHandler.result().getString(USER_ID),
-                        authHandler.result().getString(USER_ROLE)));
+                        authHandler.result().getString(USER_ROLE),
+                        authHandler.result().getString(ORGANIZATION_ID),
+                        authHandler.result().getString(ORGANIZATION_NAME)));
                   }
                 } else {
                   response.setStatusCode(404)
@@ -820,6 +828,8 @@ public final class CrudApis {
         .put(CREATED_AT, createdAt)
         .put(USERID, metadata.userId)
         .put(ROLE, metadata.getRole())
+        .put(ORG_ID, metadata.orgId)
+        .put(ORG_NAME, metadata.orgName)
         .put(OPERATION, metadata.getOperation())
         .put(SHORT_DESCRIPTION, metadata.shortDescription)
         .put(MYACTIVITY_ENABLED, true);

--- a/src/main/java/iudx/catalogue/server/auditing/util/AuditMetadata.java
+++ b/src/main/java/iudx/catalogue/server/auditing/util/AuditMetadata.java
@@ -20,10 +20,12 @@ public class AuditMetadata {
   public final String userId;
   public final String userRole;
   public final String shortDescription;
+  public final String orgId;
+  public final String orgName;
 
   public AuditMetadata(String itemId, String shortDescription, String apiEndpoint,
                        String httpMethod, String itemType, String itemName, String userId,
-                       String userRole) {
+                       String userRole, String orgId, String orgName) {
     this.itemId = itemId;
     this.apiEndpoint = apiEndpoint;
     this.httpMethod = httpMethod;
@@ -32,6 +34,8 @@ public class AuditMetadata {
     this.userId = userId;
     this.userRole = userRole;
     this.shortDescription = shortDescription;
+    this.orgId = orgId;
+    this.orgName = orgName;
   }
 
   public String getOperation() {

--- a/src/main/java/iudx/catalogue/server/auditing/util/Constants.java
+++ b/src/main/java/iudx/catalogue/server/auditing/util/Constants.java
@@ -40,6 +40,9 @@ public class Constants {
   /* Auditing Service Constants*/
   public static final String USER_ROLE = "user_role";
   public static final String ROLE = "role";
+  public static final String ORG_ID = "org_id";
+  public static final String ORG_NAME = "org_name";
+
 
   public static final String USER_ID = "userID";
 

--- a/src/main/java/iudx/catalogue/server/authenticator/KcAuthenticationServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/authenticator/KcAuthenticationServiceImpl.java
@@ -185,7 +185,8 @@ public class KcAuthenticationServiceImpl implements AuthenticationService {
         || endpoint.equals(api.getRouteMlayerDomains())
         || endpoint.equals(api.getRouteSearch())
         || endpoint.equals(api.getRouteSearchMyAssets())
-        || endpoint.equals(api.getRouteListMulItems())) {
+        || endpoint.equals(api.getRouteListMulItems())
+        || endpoint.equals(api.getRouteCount())) {
       promise.complete(true);
     } else {
       LOGGER.error("Unauthorized access to endpoint {}", endpoint);


### PR DESCRIPTION
- Added org_id and org_name for provider, cos_admin, consumer in the audit log. The fields can be null
- Sample audit log
```json
 {
  "asset_id" : "ea8f1b8c-f18c-4d5b-b5e0-00c000420c73",
  "api" : "/iudx/cat/v1/item",
  "method" : "GET",
  "asset_type" : "adex:DataBank",
  "asset_name" : "databank1",
  "created_at" : "2025-06-27T11:57:20.401085466",
  "user_id" : "ef93843a-c8e5-4c92-a8a0-a7a9f5470769",
  "role" : "consumer",
  "org_id" : "0228ebcd-e20c-453e-a66d-131250cfb0d3",
  "org_name" : "Test 12",
  "operation" : "View",
  "short_description" : "dataBankId",
  "myactivity_enabled" : true
}