### PR TITLE
Update regex pattern for `name` field in resource schema

### DIFF
--- a/src/main/resources/iudx/catalogue/server/validator/adexAiModelItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/adexAiModelItemSchema.json
@@ -54,7 +54,7 @@
       "default": "",
       "examples": ["SomePlace"],
       "maxLength": 512,
-      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9 _\\-:,;)(]*$"
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9 _\\-:,;./)(]*$"
     },
     "id": {
       "$id": "#/properties/id",

--- a/src/main/resources/iudx/catalogue/server/validator/adexAppsItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/adexAppsItemSchema.json
@@ -82,7 +82,7 @@
       "default": "",
       "examples": ["SomePlace"],
       "maxLength": 512,
-      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9 _\\-:,;)(]*$"
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9 _\\-:,;./)(]*$"
     },
     "id": {
       "$id": "#/properties/id",

--- a/src/main/resources/iudx/catalogue/server/validator/adexDataBankResourceItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/adexDataBankResourceItemSchema.json
@@ -53,7 +53,7 @@
       "default": "",
       "examples": ["SomePlace"],
       "maxLength": 512,
-      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9 _\\-:,;)(]*$"
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9 _\\-:,;./)(]*$"
     },
     "id": {
       "$id": "#/properties/id",


### PR DESCRIPTION
### Summary:
This PR updates the regex pattern for the `name` field in the metadata schema to allow a wider range of valid characters.

### Changes:
- Previous pattern: `^[a-zA-Z0-9][a-zA-Z0-9 _\-:,;)(]*$`
- New pattern: `^[a-zA-Z0-9][a-zA-Z0-9 _\-:,;./)(]*$`
  - Added `/` and `.` to the allowed characters.

### Reason:
Certain valid dataset names may include slashes (`/`) and dots (`.`), which were previously rejected by the strict pattern. This change accommodates more realistic naming conventions.

No functional code changes. Only schema validation update.
