### PR TITLE
added ogcResourceInfo field

### DIFF
--- a/src/main/java/iudx/catalogue/server/database/Constants.java
+++ b/src/main/java/iudx/catalogue/server/database/Constants.java
@@ -168,7 +168,8 @@ public class Constants {
           + " \"dataDescriptor\", \"@context\", \"dataQualityFile\", \"dataSampleFile\","
           + " \"resourceType\", \"resourceServerRegURL\",\"resourceType\","
           + "\"location\", \"iudxResourceAPIs\", \"itemCreatedAt\",\"nsdi\", "
-          + "\"icon_base64\", \"tags\"]},\"size\": 10000}";
+          + "\"icon_base64\", \"tags\",\"ogcResourceInfo\"]},\"size\": 10000}";
+
   public static final String RESOURCE_ACCESSPOLICY_COUNT =
       "{\"size\": 0,\"aggs\":{\"results\":{\"terms\":{\"field\":\"resourceGroup.keyword\","
           + "\"size\":10000},\"aggs\":{\"access_policies\":{\"terms\":{\"field\":"


### PR DESCRIPTION
Updated the POST /internal/ui/dataset to give field "ogcResourceInfo" in response when the request body consists of id of the resource group. 