### PR TITLE
Add User/Org Asset Management APIs, Ownership Operations, Default Publish Flow, and Logging Enhancements

### DIFF
--- a/configs/indices-mappings/cat_mappings.json
+++ b/configs/indices-mappings/cat_mappings.json
@@ -295,6 +295,15 @@
                     }
                 }
             },
+            "publishStatus": {
+                "type": "text",
+                "fields": {
+                    "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                    }
+                }
+            },
             "iudxResourceAPIs": {
                 "type": "text",
                 "fields": {

--- a/src/main/java/iudx/catalogue/server/apiserver/CrudApis.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/CrudApis.java
@@ -12,7 +12,6 @@ import static iudx.catalogue.server.auditing.util.Constants.ROLE;
 import static iudx.catalogue.server.authenticator.Constants.API_ENDPOINT;
 import static iudx.catalogue.server.authenticator.Constants.TOKEN;
 import static iudx.catalogue.server.database.Constants.ACCESS_POLICY;
-import static iudx.catalogue.server.database.Constants.OPEN;
 import static iudx.catalogue.server.database.Constants.PRIVATE;
 import static iudx.catalogue.server.util.Constants.*;
 import static iudx.catalogue.server.util.Constants.DETAIL;
@@ -337,7 +336,7 @@ public final class CrudApis {
                             authHandler.result().getString(USER_ID),
                             authHandler.result().getString(USER_ROLE),
                             authHandler.result().getString(ORGANIZATION_ID),
-                            authHandler.result().getString(ORGANIZATION_NAME)));
+                            authHandler.result().getString(ORGANIZATION_NAME), true));
                       }
                     }
                   });
@@ -360,7 +359,7 @@ public final class CrudApis {
                             authHandler.result().getString(USER_ID),
                             authHandler.result().getString(USER_ROLE),
                             authHandler.result().getString(ORGANIZATION_ID),
-                            authHandler.result().getString(ORGANIZATION_NAME)));
+                            authHandler.result().getString(ORGANIZATION_NAME), true));
                       }
                     } else if (dbhandler.failed()) {
                       LOGGER.error("Fail: Item update;" + dbhandler.cause().getMessage());
@@ -391,6 +390,7 @@ public final class CrudApis {
     response.putHeader(HEADER_CONTENT_TYPE, MIME_APPLICATION_JSON);
 
     String itemId = routingContext.queryParams().get(ID);
+    boolean myActivityEnabled = Boolean.parseBoolean(routingContext.queryParams().get(MY_ACTIVITY));
     String token = routingContext.get(HEADER_TOKEN);
 
     LOGGER.debug("Info: Getting item; id=" + itemId);
@@ -479,7 +479,8 @@ public final class CrudApis {
                     authHandler.result().getString(USER_ID),
                     authHandler.result().getString(USER_ROLE),
                     authHandler.result().getString(ORGANIZATION_ID),
-                    authHandler.result().getString(ORGANIZATION_NAME)
+                    authHandler.result().getString(ORGANIZATION_NAME),
+                    myActivityEnabled
                 ));
               }
             }
@@ -511,7 +512,8 @@ public final class CrudApis {
                   authHandler.result().getString(USER_ID),
                   authHandler.result().getString(USER_ROLE),
                   authHandler.result().getString(ORGANIZATION_ID),
-                  authHandler.result().getString(ORGANIZATION_NAME)
+                  authHandler.result().getString(ORGANIZATION_NAME),
+                  myActivityEnabled
               ));
             }
           });
@@ -666,7 +668,7 @@ public final class CrudApis {
                         authHandler.result().getString(USER_ID),
                         authHandler.result().getString(USER_ROLE),
                         authHandler.result().getString(ORGANIZATION_ID),
-                        authHandler.result().getString(ORGANIZATION_NAME)));
+                        authHandler.result().getString(ORGANIZATION_NAME), true));
                   }
                 } else {
                   response.setStatusCode(404)
@@ -877,7 +879,7 @@ public final class CrudApis {
         .put(ORG_NAME, metadata.orgName)
         .put(OPERATION, metadata.getOperation())
         .put(SHORT_DESCRIPTION, metadata.shortDescription)
-        .put(MYACTIVITY_ENABLED, true);
+        .put(MY_ACTIVITY_ENABLED, metadata.myActivityEnabled);
 
     LOGGER.debug("audit data: " + auditInfo.encodePrettily());
 

--- a/src/main/java/iudx/catalogue/server/apiserver/MyAssetsApis.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/MyAssetsApis.java
@@ -1,0 +1,334 @@
+package iudx.catalogue.server.apiserver;
+
+import static iudx.catalogue.server.apiserver.util.Constants.*;
+import static iudx.catalogue.server.authenticator.Constants.*;
+import static iudx.catalogue.server.database.Constants.*;
+import static iudx.catalogue.server.util.Constants.*;
+import static iudx.catalogue.server.util.Constants.METHOD;
+
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+import iudx.catalogue.server.apiserver.util.QueryMapper;
+import iudx.catalogue.server.apiserver.util.RespBuilder;
+import iudx.catalogue.server.authenticator.AuthenticationService;
+import iudx.catalogue.server.database.DatabaseService;
+import iudx.catalogue.server.util.Api;
+import iudx.catalogue.server.validator.ValidatorService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class MyAssetsApis {
+  private static final Logger LOGGER = LogManager.getLogger(MyAssetsApis.class);
+  private final Api api;
+  private DatabaseService dbService;
+  private ValidatorService validatorService;
+  private AuthenticationService authService;
+
+  public MyAssetsApis(Api api) {
+    this.api = api;
+  }
+
+  /**
+   * Sets the database service, validator service, and auth service for this class.
+   *
+   * @param dbService        the database service to be set
+   * @param validatorService the validator service to be set
+   * @param authService      the authservice to be set
+   */
+  public void setService(DatabaseService dbService, ValidatorService validatorService,
+                         AuthenticationService authService) {
+    this.dbService = dbService;
+    this.validatorService = validatorService;
+    this.authService = authService;
+  }
+
+  public void getSearchHandler(RoutingContext routingContext) {
+    HttpServerRequest request = routingContext.request();
+    HttpServerResponse response = routingContext.response();
+    response.putHeader(HEADER_CONTENT_TYPE, MIME_APPLICATION_JSON);
+
+    String token = routingContext.get(HEADER_TOKEN);
+    String instanceId = request.getHeader(HEADER_INSTANCE);
+
+    // Set defaults
+    int size = DEFAULT_MAX_PAGE_SIZE;
+    int page = DEFAULT_PAGE_NUMBER;
+
+    if (request.getParam(SIZE_KEY) != null) {
+      try {
+        size = Integer.parseInt(request.getParam(SIZE_KEY));
+      } catch (NumberFormatException e) {
+        LOGGER.warn("Invalid size param, defaulting to {}", size);
+      }
+    }
+
+    if (request.getParam(PAGE_KEY) != null) {
+      try {
+        page = Integer.parseInt(request.getParam(PAGE_KEY));
+      } catch (NumberFormatException e) {
+        LOGGER.warn("Invalid page param, defaulting to {}", page);
+      }
+    }
+
+    int offset = size * (page - 1);
+
+    if (token != null && !token.isEmpty()) {
+      JsonObject jwtAuthenticationInfo = new JsonObject()
+          .put(TOKEN, token)
+          .put(METHOD, REQUEST_GET)
+          .put(API_ENDPOINT, routingContext.normalizedPath());
+
+      int finalSize = size;
+      int finalPage = page;
+      authService.tokenInterospect(new JsonObject(), jwtAuthenticationInfo, authHandler -> {
+        if (authHandler.failed()) {
+          LOGGER.error("Unauthorized access: {}", authHandler.cause().getMessage());
+          response.setStatusCode(401).end(new RespBuilder()
+              .withType(TYPE_TOKEN_INVALID)
+              .withTitle(TITLE_TOKEN_INVALID)
+              .withDetail(authHandler.cause().getMessage())
+              .getResponse());
+        } else {
+          String userId = authHandler.result().getString(SUB);
+
+          JsonObject requestBody = new JsonObject()
+              .put(SUB, userId)
+              .put(MY_ASSETS_REQ, true)
+              .put(SEARCH_TYPE, SEARCH_TYPE_MY_ASSETS_ALL)
+              .put(SIZE_KEY, finalSize)
+              .put(LIMIT, finalSize)
+              .put(PAGE_KEY, finalPage)
+              .put(OFFSET, offset);
+          QueryMapper.extractSortFromRawUri(routingContext.request().uri(), requestBody);
+
+          // Also include instance if present
+          if (instanceId != null) {
+            requestBody.put(HEADER_INSTANCE, instanceId);
+          }
+
+          dbService.searchQuery(requestBody, handler -> {
+            if (handler.succeeded()) {
+              JsonObject resultJson = handler.result();
+              String status = resultJson.getString(STATUS);
+              if (status.equalsIgnoreCase(SUCCESS)) {
+                LOGGER.info("Success: GET /my-assets");
+                response.setStatusCode(200);
+              } else if (status.equalsIgnoreCase(PARTIAL_CONTENT)) {
+                response.setStatusCode(206);
+              } else {
+                LOGGER.error("Fail: search query");
+                response.setStatusCode(400);
+              }
+              response.end(resultJson.toString());
+            } else {
+              LOGGER.error("Fail: GET /my-assets; {}", handler.cause().getMessage());
+              response.setStatusCode(400).end(handler.cause().getMessage());
+            }
+          });
+        }
+      });
+    } else {
+      LOGGER.warn("Missing auth token");
+      response.setStatusCode(401).end(new RespBuilder()
+          .withType(TYPE_MISSING_TOKEN)
+          .withTitle(TITLE_MISSING_TOKEN)
+          .withDetail("Token is required for /search/myassets")
+          .getResponse());
+    }
+  }
+
+  /**
+   * Processes the attribute, temporal, range, geoSpatial, and text search  POST requests and
+   * returns the results
+   * from the
+   * database.
+   *
+   * @param routingContext Handles web request in Vert.x web
+   */
+  public void postSearchHandler(RoutingContext routingContext) {
+    HttpServerRequest request = routingContext.request();
+    HttpServerResponse response = routingContext.response();
+    response.putHeader(HEADER_CONTENT_TYPE, MIME_APPLICATION_JSON);
+
+    JsonObject requestBody = routingContext.body().asJsonObject();
+
+    /* HTTP request instance/host details */
+    String instanceId = request.getHeader(HEADER_INSTANCE);
+    requestBody.put(HEADER_INSTANCE, instanceId);
+
+    // Set default size and page
+    int size = DEFAULT_MAX_PAGE_SIZE;
+    int page = DEFAULT_PAGE_NUMBER;
+
+    // Override if query params are present
+    if (request.getParam(SIZE_KEY) != null) {
+      try {
+        size = Integer.parseInt(request.getParam(SIZE_KEY));
+      } catch (NumberFormatException e) {
+        LOGGER.warn("Invalid size param, defaulting to 100");
+      }
+    }
+
+    if (request.getParam(PAGE_KEY) != null) {
+      try {
+        page = Integer.parseInt(request.getParam(PAGE_KEY));
+      } catch (NumberFormatException e) {
+        LOGGER.warn("Invalid page param, defaulting to 1");
+      }
+    }
+
+    int offset = size * (page - 1);
+
+    requestBody.put(SIZE_KEY, size);
+    requestBody.put(LIMIT, size);
+    requestBody.put(PAGE_KEY, page);
+    requestBody.put(OFFSET, offset);
+
+    QueryMapper.extractSortFromRawUri(routingContext.request().uri(), requestBody);
+
+    String token = routingContext.get(HEADER_TOKEN);
+    if (token != null && !token.isEmpty()) {
+      JsonObject jwtAuthenticationInfo = new JsonObject()
+          .put(TOKEN, token)
+          .put(METHOD, REQUEST_GET)
+          .put(API_ENDPOINT, routingContext.normalizedPath());
+
+      authService.tokenInterospect(new JsonObject(), jwtAuthenticationInfo, authHandler -> {
+        if (authHandler.failed()) {
+          LOGGER.error("Error: " + authHandler.cause().getMessage());
+          response.setStatusCode(401)
+              .end(new RespBuilder()
+                  .withType(TYPE_TOKEN_INVALID)
+                  .withTitle(TITLE_TOKEN_INVALID)
+                  .withDetail(authHandler.cause().getMessage())
+                  .getResponse());
+        } else {
+          requestBody.put(SUB, authHandler.result().getString(SUB));
+          processSearch(request, response, requestBody);
+        }
+      });
+    } else {
+      // No token provided, proceed without "sub"
+      processSearch(request, response, requestBody);
+    }
+  }
+
+  private void processSearch(HttpServerRequest request, HttpServerResponse response,
+                             JsonObject requestBody) {
+    boolean hasValidFilter = false;
+
+    if ((!requestBody.containsKey(SEARCH_CRITERIA_KEY)
+        || requestBody.getJsonArray(SEARCH_CRITERIA_KEY).isEmpty())
+        && (!requestBody.containsKey(GEOPROPERTY)
+        || !requestBody.containsKey(GEORELATION)
+        || !requestBody.containsKey(GEOMETRY)
+        || !requestBody.containsKey(COORDINATES))
+        && !requestBody.containsKey(Q_VALUE)) {
+
+      LOGGER.error("Fail: Invalid Syntax");
+      response.setStatusCode(400)
+          .end(new RespBuilder()
+              .withType(TYPE_INVALID_SYNTAX)
+              .withTitle(TITLE_INVALID_SYNTAX)
+              .withDetail("Mandatory field(s) not provided")
+              .getResponse());
+      return;
+    }
+
+    /* SEARCH_CRITERIA filter (attribute, temporal, range) */
+    if (requestBody.getJsonArray(SEARCH_CRITERIA_KEY) != null
+        && !requestBody.getJsonArray(SEARCH_CRITERIA_KEY).isEmpty()) {
+      requestBody.put(SEARCH_TYPE, requestBody.getString(SEARCH_TYPE, "") + SEARCH_TYPE_CRITERIA);
+      hasValidFilter = true;
+    }
+
+    /* GEO filter */
+    if (GEOMETRIES.contains(requestBody.getString(GEOMETRY))
+        && GEORELS.contains(requestBody.getString(GEORELATION))
+        && GEO_PROPERTY.equals(requestBody.getString(GEOPROPERTY))) {
+      requestBody.put(SEARCH_TYPE, requestBody.getString(SEARCH_TYPE, "") + SEARCH_TYPE_GEO);
+      hasValidFilter = true;
+    }
+
+    /* TEXT filter */
+    if (requestBody.getString(Q_VALUE) != null && !requestBody.getString(Q_VALUE).isBlank()) {
+      requestBody.put(SEARCH_TYPE, requestBody.getString(SEARCH_TYPE, "") + SEARCH_TYPE_TEXT);
+      hasValidFilter = true;
+    }
+
+    /* TAG filter */
+    if (requestBody.containsKey(FILTER) && requestBody.getJsonArray(FILTER) != null) {
+      requestBody.put(SEARCH_TYPE, requestBody.getString(SEARCH_TYPE, "") + RESPONSE_FILTER);
+      hasValidFilter = true;
+    }
+
+    /* If none of the filters are valid, respond with 400 */
+    if (!hasValidFilter) {
+      LOGGER.error("Fail: Invalid Syntax");
+      response.setStatusCode(400)
+          .end(new RespBuilder()
+              .withType(TYPE_INVALID_SYNTAX)
+              .withTitle(TITLE_INVALID_SYNTAX)
+              .withDetail("Mandatory field(s) not provided")
+              .getResponse());
+      return;
+    }
+
+    validatorService.validateSearchQuery(requestBody, validateHandler -> {
+      if (validateHandler.failed()) {
+        LOGGER.error("Fail: Search/Count; Invalid request query parameters");
+        response.setStatusCode(400)
+            .end(validateHandler.cause().getLocalizedMessage());
+      } else {
+        String path = request.path();
+        requestBody.put(MY_ASSETS_REQ, true);
+        if (path.equals(api.getRouteSearchMyAssets())) {
+          dbService.searchQuery(requestBody, handler -> {
+            if (handler.succeeded()) {
+              JsonObject resultJson = handler.result();
+              String status = resultJson.getString(STATUS);
+              if (status.equalsIgnoreCase(SUCCESS)) {
+                LOGGER.info("Success: search query");
+                response.setStatusCode(200);
+              } else if (status.equalsIgnoreCase(PARTIAL_CONTENT)) {
+                LOGGER.info("Success: search query");
+                response.setStatusCode(206);
+              } else {
+                LOGGER.error("Fail: search query");
+                response.setStatusCode(400);
+              }
+              response.end(resultJson.toString());
+            } else if (handler.failed()) {
+              LOGGER.error("Fail: Search;" + handler.cause().getMessage());
+              response.setStatusCode(400).end(handler.cause().getMessage());
+            }
+          });
+        } else {
+          dbService.countQuery(requestBody, handler -> {
+            if (handler.succeeded()) {
+              JsonObject resultJson = handler.result();
+              String status = resultJson.getString(STATUS);
+              if (status.equalsIgnoreCase(SUCCESS)) {
+                LOGGER.info("Success: count query");
+                response.setStatusCode(200);
+              } else if (status.equalsIgnoreCase(PARTIAL_CONTENT)) {
+                LOGGER.info("Success: count query");
+                response.setStatusCode(206);
+              } else {
+                LOGGER.error("Fail: count query");
+                response.setStatusCode(400);
+              }
+              response.end(resultJson.toString());
+            } else if (handler.failed()) {
+              LOGGER.error("Fail: Count;" + handler.cause().getMessage());
+              response.setStatusCode(400)
+                  .end(handler.cause().getMessage());
+            }
+          });
+        }
+      }
+    });
+  }
+}

--- a/src/main/java/iudx/catalogue/server/apiserver/OrganisationApis.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/OrganisationApis.java
@@ -1,0 +1,189 @@
+package iudx.catalogue.server.apiserver;
+
+import static iudx.catalogue.server.apiserver.util.Constants.*;
+import static iudx.catalogue.server.authenticator.Constants.*;
+import static iudx.catalogue.server.database.Constants.*;
+import static iudx.catalogue.server.util.Constants.*;
+import static iudx.catalogue.server.util.Constants.METHOD;
+
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+import iudx.catalogue.server.apiserver.util.QueryMapper;
+import iudx.catalogue.server.apiserver.util.RespBuilder;
+import iudx.catalogue.server.authenticator.AuthenticationService;
+import iudx.catalogue.server.database.DatabaseService;
+import iudx.catalogue.server.util.Api;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class OrganisationApis {
+  private static final Logger LOGGER = LogManager.getLogger(OrganisationApis.class);
+  private final Api api;
+  private DatabaseService dbService;
+  private AuthenticationService authService;
+
+  public OrganisationApis(Api api) {
+    this.api = api;
+  }
+
+  /**
+   * Sets the database service, and auth service for this class.
+   *
+   * @param dbService        the database service to be set
+   * @param authService      the authservice to be set
+   */
+  public void setService(DatabaseService dbService, AuthenticationService authService) {
+    this.dbService = dbService;
+    this.authService = authService;
+  }
+
+  public void partialUpdateItemHandler(RoutingContext ctx) {
+    HttpServerResponse response = ctx.response();
+    response.putHeader(HEADER_CONTENT_TYPE, MIME_APPLICATION_JSON);
+
+    JsonObject jwtAuthenticationInfo = new JsonObject();
+
+    // populating jwt authentication info ->
+    jwtAuthenticationInfo
+        .put(TOKEN, ctx.get(HEADER_TOKEN))
+        .put(METHOD, REQUEST_PATCH)
+        .put(API_ENDPOINT, api.getRouteOrgAsset());
+    JsonObject requestBody = ctx.body().asJsonObject();
+
+    authService.tokenInterospect(new JsonObject(),
+        jwtAuthenticationInfo, authHandler -> {
+          if (authHandler.failed()) {
+            LOGGER.error("Error: " + authHandler.cause().getMessage());
+            response.setStatusCode(401)
+                .end(new RespBuilder()
+                    .withType(TYPE_TOKEN_INVALID)
+                    .withTitle(TITLE_TOKEN_INVALID)
+                    .withDetail(authHandler.cause().getMessage())
+                    .getResponse());
+          } else {
+            LOGGER.debug("Success: JWT Auth successful");
+
+            String itemId = ctx.request().getParam(ID);
+            if (itemId == null || itemId.isEmpty()) {
+              response.setStatusCode(400)
+                  .end(new JsonObject().put("error", "Missing or invalid item ID").encode());
+              return;
+            }
+
+            // Optionally validate token, role, etc. here
+
+            requestBody.put(ID, itemId);
+
+            dbService.partialUpdate(requestBody, dbRes -> {
+              if (dbRes.succeeded()) {
+                LOGGER.debug("Success: " + dbRes.result());
+                JsonObject result = dbRes.result();
+                response.setStatusCode(200)
+                    .end(new RespBuilder()
+                        .withType(TYPE_SUCCESS)
+                        .withTitle(TITLE_SUCCESS)
+                        .withResult(new JsonArray().add(result))
+                        .withDetail("Item updated successfully")
+                        .getJsonResponse().encodePrettily());
+              } else {
+                if (dbRes.cause().getMessage().contains(TYPE_ITEM_NOT_FOUND)) {
+                  response.setStatusCode(404).end(dbRes.cause().getMessage());
+                } else {
+                  response.setStatusCode(400).end(dbRes.cause().getMessage());
+                }
+              }
+            });
+          }
+        });
+  }
+
+  public void getItemsByOrgHandler(RoutingContext ctx) {
+    HttpServerResponse response = ctx.response();
+    HttpServerRequest request = ctx.request();
+    response.putHeader(HEADER_CONTENT_TYPE, MIME_APPLICATION_JSON);
+
+    JsonObject requestBody = new JsonObject();
+    // Set default size and page
+    int size = DEFAULT_MAX_PAGE_SIZE;
+    int page = DEFAULT_PAGE_NUMBER;
+
+    // Override if query params are present
+    if (request.getParam(SIZE_KEY) != null) {
+      try {
+        size = Integer.parseInt(request.getParam(SIZE_KEY));
+      } catch (NumberFormatException e) {
+        LOGGER.warn("Invalid size param, defaulting to {}", size);
+      }
+    }
+
+    if (request.getParam(PAGE_KEY) != null) {
+      try {
+        page = Integer.parseInt(request.getParam(PAGE_KEY));
+      } catch (NumberFormatException e) {
+        LOGGER.warn("Invalid page param, defaulting to {}", page);
+      }
+    }
+
+    int offset = size * (page - 1);
+
+    requestBody.put(SIZE_KEY, size);
+    requestBody.put(LIMIT, size);
+    requestBody.put(PAGE_KEY, page);
+    requestBody.put(OFFSET, offset);
+
+    QueryMapper.extractSortFromRawUri(request.uri(), requestBody);
+
+    // Build JWT auth info
+    JsonObject jwtAuthenticationInfo = new JsonObject()
+        .put(TOKEN, ctx.get(HEADER_TOKEN))
+        .put(METHOD, REQUEST_GET)
+        .put(API_ENDPOINT, api.getRouteOrgAsset());
+
+    authService.tokenInterospect(new JsonObject(), jwtAuthenticationInfo, authHandler -> {
+      if (authHandler.failed()) {
+        LOGGER.error("Token validation failed: " + authHandler.cause().getMessage());
+        response.setStatusCode(401)
+            .end(new RespBuilder()
+                .withType(TYPE_TOKEN_INVALID)
+                .withTitle(TITLE_TOKEN_INVALID)
+                .withDetail(authHandler.cause().getMessage())
+                .getJsonResponse().encodePrettily());
+      } else {
+        LOGGER.debug("Success: JWT Auth successful");
+        JsonObject authResult = authHandler.result();
+        String orgId = authResult.getString(ORGANIZATION_ID);
+        requestBody.put(ORGANIZATION_ID, orgId);
+
+        if (orgId == null || orgId.isEmpty()) {
+          response.setStatusCode(400)
+              .end(new JsonObject().put(ERROR, "Missing organizationId in token").encode());
+          return;
+        }
+
+        dbService.getDocsByOrgId(requestBody, dbHandler -> {
+          if (dbHandler.succeeded()) {
+            JsonObject resultJson = dbHandler.result();
+            String status = resultJson.getString(STATUS);
+            if (status.equalsIgnoreCase(SUCCESS)) {
+              LOGGER.info("Success: search query");
+              response.setStatusCode(200);
+            } else if (status.equalsIgnoreCase(PARTIAL_CONTENT)) {
+              LOGGER.info("Success: search query");
+              response.setStatusCode(206);
+            } else {
+              LOGGER.error("Fail: search query");
+              response.setStatusCode(400);
+            }
+            response.end(resultJson.toString());
+          } else if (dbHandler.failed()) {
+            LOGGER.error("Fail: Search;" + dbHandler.cause().getMessage());
+            response.setStatusCode(400).end(dbHandler.cause().getMessage());
+          }
+        });
+      }
+    });
+  }
+}

--- a/src/main/java/iudx/catalogue/server/apiserver/OwnershipApis.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/OwnershipApis.java
@@ -1,0 +1,175 @@
+package iudx.catalogue.server.apiserver;
+
+import static iudx.catalogue.server.apiserver.util.Constants.*;
+import static iudx.catalogue.server.authenticator.Constants.API_ENDPOINT;
+import static iudx.catalogue.server.authenticator.Constants.TOKEN;
+import static iudx.catalogue.server.util.Constants.*;
+
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+import iudx.catalogue.server.authenticator.AuthenticationService;
+import iudx.catalogue.server.database.DatabaseService;
+import iudx.catalogue.server.database.RespBuilder;
+import iudx.catalogue.server.util.Api;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class OwnershipApis {
+
+  private static final Logger LOGGER = LogManager.getLogger(OwnershipApis.class);
+  private final Api api;
+  private DatabaseService dbService;
+  private AuthenticationService authService;
+
+  public OwnershipApis(Api api) {
+    this.api = api;
+  }
+
+  public void setDbService(DatabaseService dbService) {
+    this.dbService = dbService;
+  }
+
+  public void setAuthService(AuthenticationService authService) {
+    this.authService = authService;
+  }
+
+  public void transferOwnershipHandler(RoutingContext routingContext) {
+    HttpServerResponse response = routingContext.response();
+    response.putHeader(HEADER_CONTENT_TYPE, MIME_APPLICATION_JSON);
+    JsonObject requestBody = routingContext.body().asJsonObject();
+
+    String oldUserId = requestBody.getString(OLD_USER_ID);
+    String newUserId = requestBody.getString(NEW_USER_ID);
+
+    JsonObject jwtAuthenticationInfo = new JsonObject();
+    jwtAuthenticationInfo
+        .put(TOKEN, routingContext.get(HEADER_TOKEN))
+        .put(METHOD, REQUEST_POST)
+        .put(API_ENDPOINT, api.getRouteOwnershipTransfer());
+
+    authService.tokenInterospect(new JsonObject(), jwtAuthenticationInfo, authHandler -> {
+      if (authHandler.failed()) {
+        LOGGER.error("Error: " + authHandler.cause().getMessage());
+        response.setStatusCode(401)
+            .end(new iudx.catalogue.server.apiserver.util.RespBuilder()
+                .withType(TYPE_TOKEN_INVALID)
+                .withTitle(TITLE_TOKEN_INVALID)
+                .withDetail(authHandler.cause().getMessage())
+                .getResponse());
+      } else {
+        LOGGER.debug("Success: JWT Auth successful");
+
+        JsonObject userInfo = authHandler.result();
+        String requesterId = userInfo.getString(SUB);
+        String organizationId = userInfo.getString(ORGANIZATION_ID);
+
+        // Authorization Check: Ensure the user is transferring their own items
+        if (!requesterId.equals(oldUserId)) {
+          LOGGER.warn("Unauthorized: Requester is not the owner");
+          response.setStatusCode(403).end(new JsonObject()
+              .put(TYPE, TYPE_ACCESS_DENIED)
+              .put(TITLE, "Forbidden")
+              .put(DETAIL, "You are not authorized to transfer these items.")
+              .encode());
+          return;
+        }
+
+        //  Missing Input Check
+        if (oldUserId.isEmpty() || newUserId == null || newUserId.isEmpty()) {
+          response.setStatusCode(400)
+              .end(new JsonObject()
+                  .put(TYPE, "urn:dx:cat:InvalidInput")
+                  .put(TITLE, "Missing Parameters")
+                  .put(DETAIL, "Missing oldUserId or newUserId")
+                  .encode());
+          return;
+        }
+
+        // Proceed with the update_by_query
+        dbService.updateByQueryRequest(requestBody, organizationId, handler -> {
+          if (handler.succeeded()) {
+            JsonObject resultJson = handler.result();
+            RespBuilder respBuilder = new RespBuilder();
+            response.setStatusCode(200);
+            response.end(respBuilder
+                .withType(TYPE_SUCCESS)
+                .withTitle(TITLE_SUCCESS)
+                .withResult(resultJson)
+                .withDetail("Success: Items updated successfully")
+                .getJsonResponse().encodePrettily());
+          } else {
+            LOGGER.error("Fail: Update By Query Search;" + handler.cause().getMessage());
+            response.setStatusCode(400).end(handler.cause().getMessage());
+          }
+        });
+      }
+    });
+  }
+
+  public void deleteOwnershipHandler(RoutingContext routingContext) {
+    HttpServerResponse response = routingContext.response();
+    response.putHeader(HEADER_CONTENT_TYPE, MIME_APPLICATION_JSON);
+
+    String oldUserId = routingContext.queryParams().get(OLD_USER_ID);
+    JsonObject request = new JsonObject().put(OLD_USER_ID, oldUserId);
+
+    if (oldUserId == null) {
+      response.setStatusCode(400).end("Missing oldUserId for delete operation");
+    }
+
+    JsonObject jwtAuthenticationInfo = new JsonObject();
+    jwtAuthenticationInfo
+        .put(TOKEN, routingContext.get(HEADER_TOKEN))
+        .put(METHOD, REQUEST_DELETE)
+        .put(API_ENDPOINT, api.getRouteOwnershipDelete());
+
+    authService.tokenInterospect(new JsonObject(), jwtAuthenticationInfo, authHandler -> {
+      if (authHandler.failed()) {
+        LOGGER.error("JWT Auth failed: " + authHandler.cause().getMessage());
+        response.setStatusCode(401)
+            .end(new RespBuilder()
+                .withType(TYPE_TOKEN_INVALID)
+                .withTitle(TITLE_TOKEN_INVALID)
+                .withDetail(authHandler.cause().getMessage())
+                .getResponse());
+      } else {
+        LOGGER.debug("Success: JWT Auth successful");
+
+        JsonObject userInfo = authHandler.result();
+        String requesterId = userInfo.getString(SUB);
+        String organizationId = userInfo.getString(ORGANIZATION_ID);
+
+
+        // Authorization Check
+        if (!requesterId.equals(oldUserId)) {
+          response.setStatusCode(403).end(new RespBuilder()
+              .withType(TYPE_ACCESS_DENIED)
+              .withTitle("Forbidden")
+              .withDetail("You are not authorized to delete items owned by another user.")
+              .getResponse());
+          return;
+        }
+
+        // Proceed with deleteByQuery
+        dbService.deleteByQueryRequest(request, organizationId, handler -> {
+          if (handler.succeeded()) {
+            JsonObject resultJson = handler.result();
+            RespBuilder respBuilder = new RespBuilder();
+            response.setStatusCode(200);
+            response.end(respBuilder
+                .withType(TYPE_SUCCESS)
+                .withTitle(TITLE_SUCCESS)
+                .withResult(resultJson)
+                .withDetail("Success: Items deleted successfully")
+                .getJsonResponse().encodePrettily());
+          } else {
+            LOGGER.error("Delete by query failed: " + handler.cause().getMessage());
+            response.setStatusCode(400).end(handler.cause().getMessage());
+          }
+        });
+      }
+    });
+  }
+
+}

--- a/src/main/java/iudx/catalogue/server/apiserver/SearchApis.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/SearchApis.java
@@ -243,7 +243,7 @@ public final class SearchApis {
       try {
         size = Integer.parseInt(request.getParam(SIZE_KEY));
       } catch (NumberFormatException e) {
-        LOGGER.warn("Invalid size param, defaulting to 100");
+        LOGGER.warn("Invalid size param, defaulting to {}", size);
       }
     }
 
@@ -251,7 +251,7 @@ public final class SearchApis {
       try {
         page = Integer.parseInt(request.getParam(PAGE_KEY));
       } catch (NumberFormatException e) {
-        LOGGER.warn("Invalid page param, defaulting to 1");
+        LOGGER.warn("Invalid page param, defaulting to {}", page);
       }
     }
 
@@ -359,8 +359,7 @@ public final class SearchApis {
             .end(validateHandler.cause().getLocalizedMessage());
       } else {
         String path = request.path();
-        requestBody.put(MY_ASSETS_REQ, path.equals(api.getRouteSearchMyAssets()));
-        if (path.equals(api.getRouteSearch()) || path.equals(api.getRouteSearchMyAssets())) {
+        if (path.equals(api.getRouteSearch())) {
           dbService.searchQuery(requestBody, handler -> {
             if (handler.succeeded()) {
               JsonObject resultJson = handler.result();

--- a/src/main/java/iudx/catalogue/server/apiserver/util/Constants.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/util/Constants.java
@@ -59,6 +59,8 @@ public class Constants {
   public static final String ROUTE_ITEMS = "/item";
   public static final String ROUTE_UPDATE_ITEMS = "/item";
   public static final String ROUTE_DELETE_ITEMS = "/item";
+
+  public static final String ROUTE_ORG_ASSET = "/organisation/asset";
   public static final String ROUTE_INSTANCE = "/instance";
   public static final String ROUTE_LIST_RESOURCE_GROUP_REL = "\\/(?<id>.*)\\/resourceGroup";
 
@@ -66,6 +68,8 @@ public class Constants {
   public static final String ROUTE_SEARCH = "/search";
   public static final String ROUTE_HEALTH_LIVE = "/health/live";
   public static final String ROUTE_SEARCH_MY_ASSETS = "/search/myassets";
+  public static final String OWNERSHIP_TRANSFER_PATH = "/item/ownership/transfer";
+  public static final String OWNERSHIP_DELETE_PATH = "/item/ownership/delete";
   public static final String ROUTE_NLP_SEARCH = "/nlpsearch";
   public static final String ROUTE_LIST_ITEMS = "/list/:itemType";
   public static final String ROUTE_LIST = "/list";

--- a/src/main/java/iudx/catalogue/server/auditing/util/AuditMetadata.java
+++ b/src/main/java/iudx/catalogue/server/auditing/util/AuditMetadata.java
@@ -22,10 +22,11 @@ public class AuditMetadata {
   public final String shortDescription;
   public final String orgId;
   public final String orgName;
+  public final boolean myActivityEnabled;
 
   public AuditMetadata(String itemId, String shortDescription, String apiEndpoint,
                        String httpMethod, String itemType, String itemName, String userId,
-                       String userRole, String orgId, String orgName) {
+                       String userRole, String orgId, String orgName, boolean myActivityEnabled) {
     this.itemId = itemId;
     this.apiEndpoint = apiEndpoint;
     this.httpMethod = httpMethod;
@@ -36,6 +37,7 @@ public class AuditMetadata {
     this.shortDescription = shortDescription;
     this.orgId = orgId;
     this.orgName = orgName;
+    this.myActivityEnabled = myActivityEnabled;
   }
 
   public String getOperation() {

--- a/src/main/java/iudx/catalogue/server/auditing/util/Constants.java
+++ b/src/main/java/iudx/catalogue/server/auditing/util/Constants.java
@@ -46,7 +46,8 @@ public class Constants {
 
   public static final String USER_ID = "userID";
 
-  public static final String MYACTIVITY_ENABLED = "myactivity_enabled";
+  public static final String MY_ACTIVITY_ENABLED = "myactivity_enabled";
+  public static final String MY_ACTIVITY = "myActivity";
 
   public static final String CONSUMER = "consumer";
 

--- a/src/main/java/iudx/catalogue/server/authenticator/KcAuthenticationServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/authenticator/KcAuthenticationServiceImpl.java
@@ -127,7 +127,7 @@ public class KcAuthenticationServiceImpl implements AuthenticationService {
               }
             })
         .compose(validAdmin -> {
-          if (!httpMethod.equals(REQUEST_GET)) {
+          if (!httpMethod.equals(REQUEST_GET) || endpoint.equals(api.getRouteOrgAsset())) {
             return validateAccess(result.jwtData, authenticationInfo, itemType)
                 .compose(accessInfo -> {
                   JsonObject jwtJson = result.jwtData.toJson();
@@ -186,7 +186,10 @@ public class KcAuthenticationServiceImpl implements AuthenticationService {
         || endpoint.equals(api.getRouteSearch())
         || endpoint.equals(api.getRouteSearchMyAssets())
         || endpoint.equals(api.getRouteListMulItems())
-        || endpoint.equals(api.getRouteCount())) {
+        || endpoint.equals(api.getRouteCount())
+        || endpoint.equals(api.getRouteOrgAsset())
+        || endpoint.equals(api.getRouteOwnershipTransfer())
+        || endpoint.equals(api.getRouteOwnershipDelete())) {
       promise.complete(true);
     } else {
       LOGGER.error("Unauthorized access to endpoint {}", endpoint);
@@ -230,7 +233,7 @@ public class KcAuthenticationServiceImpl implements AuthenticationService {
     boolean authorized = false;
 
     for (String role : roles) {
-      if (!Set.of("consumer", "provider", "delegate", "admin", "cos_admin").contains(role)) {
+      if (!Set.of("consumer", "provider", "delegate", "admin", "cos_admin", "org_admin").contains(role)) {
         LOGGER.debug("Skipping unsupported role: " + role);
         continue;
       }

--- a/src/main/java/iudx/catalogue/server/authenticator/authorization/AuthorizationContextFactory.java
+++ b/src/main/java/iudx/catalogue/server/authenticator/authorization/AuthorizationContextFactory.java
@@ -29,6 +29,9 @@ public class AuthorizationContextFactory {
       case "cos_admin": {
         return CosAdminAuthStrategy.getInstance(api);
       }
+      case "org_admin": {
+        return OrgAdminAuthStrategy.getInstance(api);
+      }
       default:
         throw new IllegalArgumentException(role + "role is not defined in IUDX");
     }

--- a/src/main/java/iudx/catalogue/server/authenticator/authorization/CosAdminAuthStrategy.java
+++ b/src/main/java/iudx/catalogue/server/authenticator/authorization/CosAdminAuthStrategy.java
@@ -50,6 +50,8 @@ public class CosAdminAuthStrategy implements AuthorizationStratergy {
     accessList.add(new AuthorizationRequest(POST, api.getRouteItems(), ITEM_TYPE_APPS));
     accessList.add(new AuthorizationRequest(PUT, api.getRouteItems(), ITEM_TYPE_APPS));
     accessList.add(new AuthorizationRequest(DELETE, api.getRouteItems(), ITEM_TYPE_APPS));
+    accessList.add(new AuthorizationRequest(POST, api.getRouteOwnershipTransfer(), ""));
+    accessList.add(new AuthorizationRequest(DELETE, api.getRouteOwnershipDelete(), ""));
     accessList.add(new AuthorizationRequest(POST, api.getRouteInstance(), ITEM_TYPE_INSTANCE));
     accessList.add(new AuthorizationRequest(DELETE, api.getRouteInstance(), ITEM_TYPE_INSTANCE));
     accessList.add(new AuthorizationRequest(POST, api.getRouteMlayerInstance(), ""));

--- a/src/main/java/iudx/catalogue/server/authenticator/authorization/OrgAdminAuthStrategy.java
+++ b/src/main/java/iudx/catalogue/server/authenticator/authorization/OrgAdminAuthStrategy.java
@@ -1,0 +1,47 @@
+package iudx.catalogue.server.authenticator.authorization;
+
+import static iudx.catalogue.server.authenticator.authorization.Method.*;
+
+import iudx.catalogue.server.util.Api;
+import java.util.ArrayList;
+import java.util.List;
+
+public class OrgAdminAuthStrategy implements AuthorizationStratergy {
+
+  static List<AuthorizationRequest> accessList = new ArrayList<>();
+  private static volatile OrgAdminAuthStrategy instance;
+
+  private OrgAdminAuthStrategy(Api api) {
+    buildPermissions(api);
+  }
+
+  /**
+   * Returns a singleton instance of the AdminAuthStrategy class for the specified API.
+   *
+   * @param api the API to create an AdminAuthStrategy instance for
+   * @return a singleton instance of the AdminAuthStrategy class
+   */
+  public static OrgAdminAuthStrategy getInstance(Api api) {
+    if (instance == null) {
+      synchronized (OrgAdminAuthStrategy.class) {
+        if (instance == null) {
+          instance = new OrgAdminAuthStrategy(api);
+        }
+      }
+    }
+    return instance;
+  }
+
+  private void buildPermissions(Api api) {
+    // /item access list
+    accessList.add(new AuthorizationRequest(PATCH, api.getRouteOrgAsset(), ""));
+    accessList.add(new AuthorizationRequest(GET, api.getRouteOrgAsset(), ""));
+    accessList.add(new AuthorizationRequest(POST, api.getRouteOwnershipTransfer(), ""));
+    accessList.add(new AuthorizationRequest(DELETE, api.getRouteOwnershipDelete(), ""));
+  }
+
+  @Override
+  public boolean isAuthorized(AuthorizationRequest authRequest) {
+    return accessList.contains(authRequest);
+  }
+}

--- a/src/main/java/iudx/catalogue/server/authenticator/authorization/ProviderAuthStrategy.java
+++ b/src/main/java/iudx/catalogue/server/authenticator/authorization/ProviderAuthStrategy.java
@@ -52,6 +52,9 @@ public class ProviderAuthStrategy implements AuthorizationStratergy {
     accessList.add(new AuthorizationRequest(DELETE, api.getRouteItems(), ITEM_TYPE_RESOURCE));
     accessList.add(new AuthorizationRequest(DELETE, api.getRouteItems(), ITEM_TYPE_AI_MODEL));
     accessList.add(new AuthorizationRequest(DELETE, api.getRouteItems(), ITEM_TYPE_DATA_BANK));
+
+    accessList.add(new AuthorizationRequest(POST, api.getRouteOwnershipTransfer(), ""));
+    accessList.add(new AuthorizationRequest(DELETE, api.getRouteOwnershipDelete(), ""));
   }
 
   @Override

--- a/src/main/java/iudx/catalogue/server/database/Constants.java
+++ b/src/main/java/iudx/catalogue/server/database/Constants.java
@@ -19,6 +19,7 @@ public class Constants {
   public static final String GEOSEARCH_REGEX = "(.*)geoSearch(.*)";
   public static final String RESPONSE_FILTER_GEO = "responseFilter_geoSearch_";
   public static final String RESPONSE_FILTER_REGEX = "(.*)responseFilter(.*)";
+  public static final String MY_ASSETS_SEARCH_REGEX = "(.*)myAssetsAll(.*)";
 
   /** DB Query related. */
   public static final String MATCH_KEY = "match";

--- a/src/main/java/iudx/catalogue/server/database/DatabaseService.java
+++ b/src/main/java/iudx/catalogue/server/database/DatabaseService.java
@@ -57,6 +57,26 @@ public interface DatabaseService {
   DatabaseService searchQuery(JsonObject request, Handler<AsyncResult<JsonObject>> handler);
 
   /**
+   * Executes an asynchronous bulk update using Elasticsearch's <code>_update_by_query</code> API.
+   * <p>
+   * Typically used for ownership transfer, this method builds the update query internally
+   * from the provided {@code oldValue} and {@code newValue}.
+   * </p>
+   *
+   * @param request which is a JsonObject
+   * @param organizationId
+   * @param handler which is a Request Handler
+   * @return this {@code DatabaseService} instance (for fluent chaining)
+   */
+  @Fluent
+  DatabaseService updateByQueryRequest(JsonObject request, String organizationId,
+                                       Handler<AsyncResult<JsonObject>> handler);
+
+  @Fluent
+  DatabaseService deleteByQueryRequest(JsonObject request, String organizationId,
+                                              Handler<AsyncResult<JsonObject>> handler);
+
+  /**
    * The searchQuery implements the nlp search operation with the database.
    *
    * @param request which is a JsonObject
@@ -341,4 +361,17 @@ public interface DatabaseService {
   @Fluent
   DatabaseService getMlayerPopularDatasets(
       String instance, JsonArray highestCountResource, Handler<AsyncResult<JsonObject>> handler);
+
+  /**
+   * Partially updates an item in the Elasticsearch index.
+   *
+   * @param request JsonObject containing fields to update. Must include the document ID as "id".
+   * @param handler AsyncResult handler returning update status or error.
+   * @return this instance for chaining
+   */
+  @Fluent
+  DatabaseService partialUpdate(JsonObject request, Handler<AsyncResult<JsonObject>> handler);
+
+  @Fluent
+  DatabaseService getDocsByOrgId(JsonObject request, Handler<AsyncResult<JsonObject>> handler);
 }

--- a/src/main/java/iudx/catalogue/server/database/ElasticClient.java
+++ b/src/main/java/iudx/catalogue/server/database/ElasticClient.java
@@ -764,6 +764,50 @@ public final class ElasticClient {
   }
 
   /**
+   * updateByQueryAsync - Wrapper around Elasticsearch _update_by_query API for bulk updates.
+   *
+   * @param index Elasticsearch index to perform the update
+   * @param updatePayload JSON object containing "query" and "script"
+   * @param resultHandler Async result handler for the response
+   * @return ElasticClient instance for fluent chaining
+   */
+  public ElasticClient updateByQueryAsync(String index, JsonObject updatePayload,
+                                          Handler<AsyncResult<JsonObject>> resultHandler) {
+
+    Request updateRequest = new Request(REQUEST_POST, index + "/_update_by_query");
+    updateRequest.setJsonEntity(updatePayload.encode());
+
+    Future<JsonObject> future = docAsync(REQUEST_POST, updateRequest);
+    future.onComplete(resultHandler);
+    return this;
+  }
+
+  /**
+   * deleteByQueryAsync - Wrapper around Elasticsearch _delete_by_query API for bulk deletions.
+   *
+   * <p>This method allows asynchronous deletion of documents in an index that match the given query.
+   * The provided query should follow Elasticsearch Query DSL syntax. This is useful for ownership
+   * cleanup operations where all items belonging to a specific user (e.g., ownerUserId) need to be deleted.
+   *
+   *
+   * @param index         Elasticsearch index to perform the delete operation on.
+   * @param updatePayload JSON object containing the "query" block to match documents.
+   * @param resultHandler Async result handler for the Elasticsearch response.
+   * @return ElasticClient instance for fluent chaining.
+   */
+  public ElasticClient deleteByQueryAsync(String index, JsonObject updatePayload,
+                                          Handler<AsyncResult<JsonObject>> resultHandler) {
+
+    Request updateRequest = new Request(REQUEST_POST, index + "/_delete_by_query");
+    updateRequest.setJsonEntity(updatePayload.encode());
+
+    Future<JsonObject> future = docAsync(REQUEST_POST, updateRequest);
+    future.onComplete(resultHandler);
+    return this;
+  }
+
+
+  /**
    * DbResponseMessageBuilder} Message builder for search APIs.
    */
   private class DbResponseMessageBuilder {

--- a/src/main/java/iudx/catalogue/server/util/Api.java
+++ b/src/main/java/iudx/catalogue/server/util/Api.java
@@ -12,12 +12,15 @@ public class Api {
   private String dxApiBasePath;
   private StringBuilder routeItems;
   private StringBuilder routUpdateItems;
+  private StringBuilder routeOrgAsset;
   private StringBuilder routeDeleteItems;
   private StringBuilder routeInstance;
   private StringBuilder routeRelationship;
   private StringBuilder routeSearch;
   private StringBuilder routeHealthLive;
   private StringBuilder routeSearchMyAssets;
+  private StringBuilder routeOwnershipTransfer;
+  private StringBuilder routeOwnershipDelete;
   private StringBuilder routeNlpSearch;
   private StringBuilder routeListItems;
   private StringBuilder routeListMulItems;
@@ -64,12 +67,15 @@ public class Api {
   public void buildEndpoints() {
     routeItems = new StringBuilder(dxApiBasePath).append(ROUTE_ITEMS);
     routUpdateItems = new StringBuilder(dxApiBasePath).append(ROUTE_UPDATE_ITEMS);
+    routeOrgAsset = new StringBuilder(dxApiBasePath).append(ROUTE_ORG_ASSET);
     routeDeleteItems = new StringBuilder(dxApiBasePath).append(ROUTE_DELETE_ITEMS);
     routeInstance = new StringBuilder(dxApiBasePath).append(ROUTE_INSTANCE);
     routeRelationship = new StringBuilder(dxApiBasePath).append(ROUTE_RELATIONSHIP);
     routeSearch = new StringBuilder(dxApiBasePath).append(ROUTE_SEARCH);
     routeHealthLive = new StringBuilder(dxApiBasePath).append(ROUTE_HEALTH_LIVE);
     routeSearchMyAssets = new StringBuilder(dxApiBasePath).append(ROUTE_SEARCH_MY_ASSETS);
+    routeOwnershipTransfer = new StringBuilder(dxApiBasePath).append(OWNERSHIP_TRANSFER_PATH);
+    routeOwnershipDelete = new StringBuilder(dxApiBasePath).append(OWNERSHIP_DELETE_PATH);
     routeNlpSearch = new StringBuilder(dxApiBasePath).append(ROUTE_NLP_SEARCH);
     routeListItems = new StringBuilder(dxApiBasePath).append(ROUTE_LIST_ITEMS);
     routeListMulItems = new StringBuilder(dxApiBasePath).append(ROUTE_LIST);
@@ -100,6 +106,9 @@ public class Api {
   public String getRoutUpdateItems() {
     return routUpdateItems.toString();
   }
+  public String getRouteOrgAsset() {
+    return routeOrgAsset.toString();
+  }
 
   public String getRouteDeleteItems() {
     return routeDeleteItems.toString();
@@ -124,6 +133,14 @@ public class Api {
   public String getRouteSearchMyAssets() {
     return routeSearchMyAssets.toString();
   }
+
+  public String getRouteOwnershipTransfer() {
+    return routeOwnershipTransfer.toString();
+  }
+  public String getRouteOwnershipDelete() {
+    return routeOwnershipDelete.toString();
+  }
+
 
   public String getRouteNlpSearch() {
     return routeNlpSearch.toString();

--- a/src/main/java/iudx/catalogue/server/util/Constants.java
+++ b/src/main/java/iudx/catalogue/server/util/Constants.java
@@ -61,6 +61,8 @@ public class Constants {
   public static final String ALL = "all";
   public static final String COS = "cos";
   public static final String OWNER = "owner";
+  public static final String OLD_USER_ID = "oldUserId";
+  public static final String NEW_USER_ID = "newUserId";
   public static final String PROVIDER_USER_ID = "ownerUserId";
   public static final String MY_ASSETS_REQ = "myAssetsRequest";
   public static final String RESOURCE_SERVER_URL = "resourceServerRegURL";
@@ -151,6 +153,7 @@ public class Constants {
   public static final String RESPONSE_FILTER = "responseFilter_";
   public static final String SEARCH_TYPE_CRITERIA = "searchCriteria_";  // used in SEARCH_TYPE value
   public static final String SEARCH_CRITERIA_KEY = "searchCriteria";    // used in requestBody key
+  public static final String SEARCH_TYPE_MY_ASSETS_ALL = "myAssetsAll_";
 
 
   public static final String MESSAGE = "detail";
@@ -177,6 +180,7 @@ public class Constants {
   public static final String FILTER = "filter";
   public static final String MUST_NOT = "must_not";
   public static final String MUST = "must";
+  public static final String SHOULD = "should";
   public static final String TAGS = "tags";
   public static final String DEPARTMENT = "department";
   public static final String ORGANIZATION_TYPE = "organizationType";

--- a/src/main/java/iudx/catalogue/server/validator/Constants.java
+++ b/src/main/java/iudx/catalogue/server/validator/Constants.java
@@ -10,8 +10,10 @@ public class Constants {
 
   public static final String ITEM_STATUS = "itemStatus";
   public static final String ACTIVE = "ACTIVE";
+  public static final String PENDING = "PENDING";
   public static final String ITEM_CREATED_AT = "itemCreatedAt";
   public static final String DATA_UPLOAD_STATUS = "dataUploadStatus";
+  public static final String PUBLISH_STATUS = "publishStatus";
   public static final String MEDIA_URL = "mediaURL";
   public static final String LAST_UPDATED = "lastUpdated";
   public static final String CONTEXT = "@context";

--- a/src/main/java/iudx/catalogue/server/validator/ValidatorServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/validator/ValidatorServiceImpl.java
@@ -347,6 +347,7 @@ public class ValidatorServiceImpl implements ValidatorService {
           if (method.equalsIgnoreCase(REQUEST_POST)) {
             // On POST: Always infer from mediaURL
             request.put(DATA_UPLOAD_STATUS, mediaUrlPresent);
+            request.put(PUBLISH_STATUS, PENDING);
           } else if (method.equalsIgnoreCase(REQUEST_PUT)) {
             // On PUT: Preserve previous true if already set
             boolean wasPreviouslyUploaded = extractDataUploadStatusFromES(res.result());
@@ -360,6 +361,9 @@ public class ValidatorServiceImpl implements ValidatorService {
             } else {
               request.put(DATA_UPLOAD_STATUS, false);
             }
+
+            String publishStatus = extractPublishStatusFromES(res.result());
+            request.put(PUBLISH_STATUS, publishStatus);
           }
 
           handler.handle(Future.succeededFuture(request));
@@ -407,6 +411,7 @@ public class ValidatorServiceImpl implements ValidatorService {
           if (method.equalsIgnoreCase(REQUEST_POST)) {
             // On POST: Always infer from mediaURL
             request.put(DATA_UPLOAD_STATUS, mediaUrlPresent);
+            request.put(PUBLISH_STATUS, PENDING);
           } else if (method.equalsIgnoreCase(REQUEST_PUT)) {
             // On PUT: Preserve previous true if already set
             boolean wasPreviouslyUploaded = extractDataUploadStatusFromES(res.result());
@@ -420,6 +425,9 @@ public class ValidatorServiceImpl implements ValidatorService {
             } else {
               request.put(DATA_UPLOAD_STATUS, false);
             }
+
+            String publishStatus = extractPublishStatusFromES(res.result());
+            request.put(PUBLISH_STATUS, publishStatus);
           }
 
           handler.handle(Future.succeededFuture(request));
@@ -449,6 +457,18 @@ public class ValidatorServiceImpl implements ValidatorService {
       LOGGER.error("Error extracting mediaURL from ES", e);
     }
     return false;
+  }
+
+  private String extractPublishStatusFromES(JsonObject esResult) {
+    try {
+      JsonObject res = esResult.getJsonArray(RESULTS).getJsonObject(0);
+      if (res != null && !res.isEmpty()) {
+        return res.getString(PUBLISH_STATUS, PENDING);
+      }
+    } catch (Exception e) {
+      LOGGER.error("Error extracting mediaURL from ES", e);
+    }
+    return PENDING;
   }
 
   private void validateResourceGroup(

--- a/src/main/resources/iudx/catalogue/server/validator/adexAppsItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/adexAppsItemSchema.json
@@ -13,7 +13,8 @@
     "industry",
     "shortDescription",
     "description",
-    "organizationType"
+    "organizationType",
+    "accessPolicy"
   ],
   "properties": {
     "sections": {
@@ -145,6 +146,13 @@
       "title": "The short description schema",
       "description": "Short description about the item",
       "maxLength": 3200
+    },
+    "accessPolicy": {
+      "$id": "#/properties/accessPolicy",
+      "type": "string",
+      "title": "The access policy schema",
+      "default": "",
+      "pattern": "^(RESTRICTED|OPEN|PRIVATE)$"
     },
     "description": {
       "type": "string",

--- a/src/test/resources/AI Sandbox - CAT.postman_collection.json
+++ b/src/test/resources/AI Sandbox - CAT.postman_collection.json
@@ -631,7 +631,7 @@
 									}
 								],
 								"url": {
-									"raw": "{{host}}{{base}}/item?id={{data_bank_id}}",
+									"raw": "{{host}}{{base}}/item?id={{data_bank_id}}&myActivity=true",
 									"host": [
 										"{{host}}{{base}}"
 									],
@@ -3361,7 +3361,7 @@
 			"name": "My Assets",
 			"item": [
 				{
-					"name": "MyAssetsSearch (200)",
+					"name": "Get My Assets with filters (200)",
 					"request": {
 						"method": "POST",
 						"header": [
@@ -3404,6 +3404,240 @@
 								{
 									"key": "size",
 									"value": "1000"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get My Assets",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{orgmem_token}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{host}}{{base}}/search/myassets?sort=itemCreatedAt:asc;name:desc&page=1&size=1000",
+							"host": [
+								"{{host}}{{base}}"
+							],
+							"path": [
+								"search",
+								"myassets"
+							],
+							"query": [
+								{
+									"key": "sort",
+									"value": "itemCreatedAt:asc;name:desc"
+								},
+								{
+									"key": "page",
+									"value": "1"
+								},
+								{
+									"key": "size",
+									"value": "1000"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "organization",
+			"item": [
+				{
+					"name": "Update publishStatus or dataUploadStatus of an item",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{orgadmin1_token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"publishStatus\": \"ACTIVE\",\n    \"dataUploadStatus\": \"true\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}{{base}}/organisation/asset?id={{asset_id}}",
+							"host": [
+								"{{host}}{{base}}"
+							],
+							"path": [
+								"organisation",
+								"asset"
+							],
+							"query": [
+								{
+									"key": "id",
+									"value": "{{asset_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get all the items of an organization",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{org_admin_token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}{{base}}/organisation/asset?sort=itemCreatedAt:asc&page=1&size=1000",
+							"host": [
+								"{{host}}{{base}}"
+							],
+							"path": [
+								"organisation",
+								"asset"
+							],
+							"query": [
+								{
+									"key": "sort",
+									"value": "itemCreatedAt:asc"
+								},
+								{
+									"key": "page",
+									"value": "1"
+								},
+								{
+									"key": "size",
+									"value": "1000"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "ownership management",
+			"item": [
+				{
+					"name": "Transfer ownership",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{orgadmin1_token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"oldUserId\": \"{{oldUserId}}\",\n    \"newUserId\": \"{{newUserId}}\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}{{base}}/item/ownership/transfer",
+							"host": [
+								"{{host}}{{base}}"
+							],
+							"path": [
+								"item",
+								"ownership",
+								"transfer"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete all the items owned by an user in an organization",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{orgadmin1_token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"oldUserId\": \"{{oldUserId}}\",\n    \"newUserId\": \"{{newUserId}}\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}{{base}}/item/ownership/delete?oldUserId={{oldUserId}}",
+							"host": [
+								"{{host}}{{base}}"
+							],
+							"path": [
+								"item",
+								"ownership",
+								"delete"
+							],
+							"query": [
+								{
+									"key": "oldUserId",
+									"value": "{{oldUserId}}"
 								}
 							]
 						}


### PR DESCRIPTION
## PR Description:

This PR introduces the following **new features** and **enhancements** related to asset management and logging:

---

### A Glimpse on the New Endpoints Added:

#### 👤 **User-specific Asset APIs**

1. **POST `/search/myassets`** – _Filtered_
   - Returns assets **owned by the authenticated user**
   - Filters: `publishStatus=ACTIVE` and `dataUploadStatus=true` with other filters can be appended similar to post search api
   - **Requires token**

2. **GET `/search/myassets`** – _Unfiltered_
   - Returns **all assets owned by the user**
   - Ignores asset status
   - **Requires token**

#### 🏢 **Organisation-level Asset APIs (org_admin only)**

3. **PATCH `/organisation/asset?id={{asset
_id}}`**
   - Updates `publishStatus` and `dataUploadStatus` for a given asset
   - Only accessible by `org_admin`

4. **GET `/organisation/asset`**
   - Returns all assets owned by the organization
   - Only accessible by `org_admin`

#### 🔄 **Ownership Management APIs**

5. **POST `/item/ownership/transfer`**
   - Transfers all owned items from `oldUserId` to `newUserId`
   - Validates `oldUserId` matches token `sub`
   - _No backend check yet for verifying if `newUserId` belongs to same org_

6. **DELETE `/item/ownership/delete`**
   - Deletes all items owned by `oldUserId`
   - Validates `oldUserId` matches token `sub`

---
### 🚦 Default `publishStatus` on Ingestion

- For items of type `adex:AiModel` and `adex:DataBank`, the server automatically sets:
`"publishStatus": "PENDING"` during initial ingestion (via POST | PUT /item).

### ⚠️ Important Behavior:
- Even if `publishStatus: "ACTIVE"` is explicitly sent in the request body,
it will not be updated during updation if the current value is `"PENDING`.
- This prevents unauthorized or premature self-publishing of assets.

### How to Publish:
- An org_admin must explicitly PATCH the asset to change publishStatus to true once the review/approval flow is complete.
---

### 🧾 GET `/item` Logging Enhancement

Added support for optional `myActivity` query parameter.

- When `myActivity=true` is passed → `myactivity_enabled: true` is logged
- When absent or false → `myactivity_enabled: false` is logged
- Whereas the post, put and delete /item endpoints will return true by default
- **Previous behavior:** All requests logged `myactivity_enabled: true` unconditionally

#### ✅ Example:

```bash
curl --location 'https://.../item?id=abc123&myActivity=true' \
  --header 'Authorization: Bearer <token>'
